### PR TITLE
[Fix] Port missed pre-open-source fixes

### DIFF
--- a/app/(app)/reviews.tsx
+++ b/app/(app)/reviews.tsx
@@ -33,6 +33,7 @@ import {
   buildReviewQuestionQueue,
   DEFAULT_MAX_QUESTION_GAP,
   generateReviewQuestions,
+  rebuildReviewQueueAfterSkip,
   sortReviewItemsForQueue,
   type ReviewQueueQuestion,
 } from "../../src/utils/reviewOrdering";
@@ -97,6 +98,7 @@ export default function ReviewScreen() {
   // Track async review submissions still in-flight when session ends
   const pendingSubmissionCountRef = useRef(0);
   const hasShownReviewPermissionWarningRef = useRef(false);
+  const skippedItemIdsRef = useRef<number[]>([]);
   const {
     ankiCardMode,
     ankiGroupQuestions,
@@ -196,28 +198,6 @@ export default function ReviewScreen() {
   
   // Check if wrap up is available (more than target subjects remaining)
   const isWrapUpAvailable = getRemainingSubjectsCount() > WRAP_UP_TARGET_SUBJECTS;
-
-  const hasReadingQuestion = (reviewItem: ReviewItem): boolean => {
-    if (reviewItem.subject.object === "radical") {
-      return false;
-    }
-
-    const readings = reviewItem.subject.data.readings;
-    if (
-      reviewItem.subject.object === "vocabulary" ||
-      reviewItem.subject.object === "kana_vocabulary"
-    ) {
-      if (!readings) {
-        return false;
-      }
-
-      if (Array.isArray(readings) && readings.length === 0) {
-        return false;
-      }
-    }
-
-    return true;
-  };
 
   // Helper function to get SRS level name
   const getSRSLevelName = (stage: number): string => {
@@ -370,6 +350,7 @@ export default function ReviewScreen() {
       hasCheckedFinalSubmissionsRef.current = false;
       pendingSubmissionCountRef.current = 0;
       hasShownReviewPermissionWarningRef.current = false;
+      skippedItemIdsRef.current = [];
       setFailedSubmissions([]);
       setSubmittingResults(false);
       setReviewPermissionWarning(null);
@@ -1231,6 +1212,9 @@ export default function ReviewScreen() {
     const itemIndex = updatedItems.findIndex((ri) => ri.id === item.id);
 
     if (itemIndex === -1) return;
+    skippedItemIdsRef.current = skippedItemIdsRef.current.filter(
+      (itemId) => itemId !== item.id
+    );
 
     // For accuracy calculation: count every answer submission
     // For grouped answers (Anki mode with meaning+reading), only count once
@@ -1456,7 +1440,7 @@ export default function ReviewScreen() {
   // Handle Skip (empty-submit setting): reset item and move it to the end.
   const handleSkip = (
     item: { id: number; subject: any },
-    _questionType: "meaning" | "reading"
+    questionType: "meaning" | "reading"
   ) => {
     const reviewItem = reviewItems.find((reviewItem) => reviewItem.id === item.id);
     if (!reviewItem) {
@@ -1506,20 +1490,22 @@ export default function ReviewScreen() {
       )
     );
 
-    // Remove all remaining questions for this subject so we can reinsert a
-    // clean pair at the very end.
-    const remainingQuestions = [...activeQueue.slice(1), ...masterQueue].filter(
-      (question) => question.itemId !== item.id
-    );
-
-    const resetQuestions: ReviewQueueQuestion[] = [
-      { type: "meaning", itemId: item.id },
-    ];
-    if (!effectiveAnkiGrouping && hasReadingQuestion(reviewItem)) {
-      resetQuestions.push({ type: "reading", itemId: item.id });
-    }
-
-    const reorderedQueue = [...remainingQuestions, ...resetQuestions];
+    const useBackToBack = backToBackQuestions && !effectiveAnkiGrouping;
+    const remainingQuestions = [...activeQueue.slice(1), ...masterQueue];
+    const { queue: reorderedQueue, skippedItemIds } =
+      rebuildReviewQueueAfterSkip({
+        items: reviewItems,
+        remainingQuestions,
+        skippedItemId: item.id,
+        skippedItemIds: skippedItemIdsRef.current,
+        skippedQuestionType: questionType,
+        groupQuestions: effectiveAnkiGrouping,
+        backToBack: useBackToBack,
+        maxQuestionGap: REVIEW_MAX_QUESTION_GAP,
+        questionTypeOrderEnabled: reviewQuestionOrderEnabled,
+        questionTypeOrder: preferredQuestionType,
+      });
+    skippedItemIdsRef.current = skippedItemIds;
     const nextActiveQueue = reorderedQueue.slice(0, ACTIVE_QUEUE_SIZE);
     const nextMasterQueue = reorderedQueue.slice(ACTIVE_QUEUE_SIZE);
 

--- a/app/(app)/subject/[id].tsx
+++ b/app/(app)/subject/[id].tsx
@@ -31,7 +31,10 @@ import {
   getSubjects,
   updateStudyMaterial,
 } from "../../../src/utils/api";
-import { getSubjectById } from "../../../src/utils/cache";
+import {
+  clearStudyMaterialsCache,
+  getSubjectById,
+} from "../../../src/utils/cache";
 import { getNiaiSimilarKanjiSubjects } from "../../../src/utils/niaiSimilarKanji";
 import { useAuthStore, useSettingsStore } from "../../../src/utils/store";
 import { useTheme } from "../../../src/utils/theme";
@@ -96,6 +99,24 @@ function withTimeout<T>(
 
 function getSettledValue<T>(result: PromiseSettledResult<T>): T | null {
   return result.status === "fulfilled" ? result.value : null;
+}
+
+function mergeStudyMaterial(
+  currentMaterial: any,
+  savedMaterial: any,
+  updates: Record<string, unknown>,
+  subjectId: number
+) {
+  return {
+    ...(currentMaterial || {}),
+    ...(savedMaterial || {}),
+    data: {
+      ...(currentMaterial?.data || {}),
+      ...(savedMaterial?.data || {}),
+      subject_id: savedMaterial?.data?.subject_id || subjectId,
+      ...updates,
+    },
+  };
 }
 
 export default function SubjectDetailsScreen() {
@@ -631,6 +652,9 @@ export default function SubjectDetailsScreen() {
   const handleSaveNote = async () => {
     if (!apiToken || !id || !subjectData) return;
 
+    const subjectId = parseInt(id as string, 10);
+    if (Number.isNaN(subjectId)) return;
+
     setIsSavingNote(true);
     try {
       // Prepare updates for the note
@@ -654,16 +678,20 @@ export default function SubjectDetailsScreen() {
         // Create new study material or handle case where we think there's no material but API says otherwise
         try {
           savedMaterial = await createStudyMaterial(apiToken, {
-            subject_id: parseInt(id as string),
+            subject_id: subjectId,
             ...updates,
           });
         } catch (createError: any) {
           // If we get a 422 error, it might mean the study material already exists
           // Try to fetch study materials again and then update
           if (createError.message?.includes("422")) {
-            const studyMaterials = await getStudyMaterials(apiToken, {
-              subject_ids: [parseInt(id as string)],
-            }, { skipCache: true });
+            const studyMaterials = await getStudyMaterials(
+              apiToken,
+              {
+                subject_ids: [subjectId],
+              },
+              { skipCache: true }
+            );
 
             if (studyMaterials.data.length > 0) {
               const existingMaterial = studyMaterials.data[0];
@@ -681,11 +709,10 @@ export default function SubjectDetailsScreen() {
         }
       }
 
-      // Update local state with the saved material
-      setStudyMaterial(savedMaterial);
-
-      // Trigger a background refresh to ensure the cache is updated
-      fetchSubjectData(false); // Background refresh without loading indicator
+      await clearStudyMaterialsCache(subjectId);
+      setStudyMaterial((currentMaterial: any) =>
+        mergeStudyMaterial(currentMaterial, savedMaterial, updates, subjectId)
+      );
 
       setShowNoteModal(false);
     } catch (error) {
@@ -718,6 +745,9 @@ export default function SubjectDetailsScreen() {
   const handleSynonymsChange = async (synonyms: string[]) => {
     if (!apiToken || !id || !subjectData) return;
 
+    const subjectId = parseInt(id as string, 10);
+    if (Number.isNaN(subjectId)) return;
+
     try {
       const updates = {
         meaning_synonyms: synonyms,
@@ -736,15 +766,19 @@ export default function SubjectDetailsScreen() {
         // Create new study material
         try {
           savedMaterial = await createStudyMaterial(apiToken, {
-            subject_id: parseInt(id as string),
+            subject_id: subjectId,
             ...updates,
           });
         } catch (createError: any) {
           // If we get a 422 error, study material might already exist
           if (createError.message?.includes("422")) {
-            const studyMaterials = await getStudyMaterials(apiToken, {
-              subject_ids: [parseInt(id as string)],
-            }, { skipCache: true });
+            const studyMaterials = await getStudyMaterials(
+              apiToken,
+              {
+                subject_ids: [subjectId],
+              },
+              { skipCache: true }
+            );
 
             if (studyMaterials.data.length > 0) {
               const existingMaterial = studyMaterials.data[0];
@@ -766,7 +800,10 @@ export default function SubjectDetailsScreen() {
       // Note: We don't call fetchSubjectData here because it would immediately
       // fetch study materials from the API, which might return stale data due to
       // eventual consistency, overwriting the freshly saved synonyms.
-      setStudyMaterial(savedMaterial);
+      await clearStudyMaterialsCache(subjectId);
+      setStudyMaterial((currentMaterial: any) =>
+        mergeStudyMaterial(currentMaterial, savedMaterial, updates, subjectId)
+      );
     } catch (error) {
       console.error("❌ Error saving synonyms:", error);
       console.error("❌ Error details:", JSON.stringify(error, null, 2));

--- a/src/utils/__tests__/reviewOrdering.test.ts
+++ b/src/utils/__tests__/reviewOrdering.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_REVIEW_ORDER,
   REVIEW_ORDER_OPTIONS,
   REVIEW_TYPE_ORDER_VALUES,
+  rebuildReviewQueueAfterSkip,
   sortReviewItemsForQueue,
   type OrderableReviewItem,
 } from "../reviewOrdering";
@@ -519,5 +520,111 @@ describe("reviewOrdering", () => {
       sortedItems.map((item) => item.id)
     );
     expect(queue[0]?.itemId).toBe(42);
+  });
+
+  it("keeps preview-skipped review items spread instead of pairing each item", () => {
+    const items = Array.from({ length: 10 }, (_, index) =>
+      createTestItem({ id: index + 1 })
+    );
+    let queue = [
+      ...items.map((item) => ({ type: "meaning" as const, itemId: item.id })),
+      ...items.map((item) => ({ type: "reading" as const, itemId: item.id })),
+    ];
+    let skippedItemIds: number[] = [];
+
+    items.forEach((item) => {
+      expect(queue[0]).toEqual({ type: "meaning", itemId: item.id });
+
+      const result = rebuildReviewQueueAfterSkip({
+        items,
+        remainingQuestions: queue.slice(1),
+        skippedItemId: item.id,
+        skippedItemIds,
+        skippedQuestionType: queue[0]?.type,
+        questionTypeOrderEnabled: true,
+        questionTypeOrder: "meaning",
+        maxQuestionGap: 10,
+        randomFn: constantRandom(0),
+      });
+
+      queue = result.queue;
+      skippedItemIds = result.skippedItemIds;
+    });
+
+    expect(queue).toEqual([
+      ...items.map((item) => ({ type: "meaning" as const, itemId: item.id })),
+      ...items.map((item) => ({ type: "reading" as const, itemId: item.id })),
+    ]);
+
+    for (let index = 0; index < queue.length - 1; index += 1) {
+      expect(queue[index].itemId === queue[index + 1].itemId).toBe(false);
+    }
+  });
+
+  it("keeps skipped review items paired when back-to-back mode is enabled", () => {
+    const items = [createTestItem({ id: 51 }), createTestItem({ id: 52 })];
+    let queue = [
+      { type: "meaning" as const, itemId: 51 },
+      { type: "meaning" as const, itemId: 52 },
+      { type: "reading" as const, itemId: 51 },
+      { type: "reading" as const, itemId: 52 },
+    ];
+    let skippedItemIds: number[] = [];
+
+    [51, 52].forEach((itemId) => {
+      const result = rebuildReviewQueueAfterSkip({
+        items,
+        remainingQuestions: queue.slice(1),
+        skippedItemId: itemId,
+        skippedItemIds,
+        skippedQuestionType: queue[0]?.type,
+        backToBack: true,
+        questionTypeOrderEnabled: true,
+        questionTypeOrder: "meaning",
+        maxQuestionGap: 10,
+        randomFn: constantRandom(0),
+      });
+
+      queue = result.queue;
+      skippedItemIds = result.skippedItemIds;
+    });
+
+    expect(queue).toEqual([
+      { type: "meaning", itemId: 51 },
+      { type: "reading", itemId: 51 },
+      { type: "meaning", itemId: 52 },
+      { type: "reading", itemId: 52 },
+    ]);
+  });
+
+  it("drops stale preview-skipped ids that are no longer queued", () => {
+    const items = [
+      createTestItem({ id: 61 }),
+      createTestItem({ id: 62 }),
+      createTestItem({ id: 63 }),
+    ];
+
+    const result = rebuildReviewQueueAfterSkip({
+      items,
+      remainingQuestions: [
+        { type: "meaning", itemId: 63 },
+        { type: "reading", itemId: 63 },
+      ],
+      skippedItemId: 62,
+      skippedItemIds: [61],
+      skippedQuestionType: "meaning",
+      questionTypeOrderEnabled: true,
+      questionTypeOrder: "meaning",
+      maxQuestionGap: 10,
+      randomFn: constantRandom(0),
+    });
+
+    expect(result.skippedItemIds).toEqual([62]);
+    expect(result.queue).toEqual([
+      { type: "meaning", itemId: 63 },
+      { type: "reading", itemId: 63 },
+      { type: "meaning", itemId: 62 },
+      { type: "reading", itemId: 62 },
+    ]);
   });
 });

--- a/src/utils/reviewOrdering.ts
+++ b/src/utils/reviewOrdering.ts
@@ -123,6 +123,25 @@ interface BuildReviewQueueOptions {
   randomFn?: () => number;
 }
 
+interface RebuildReviewQueueAfterSkipOptions<T extends OrderableReviewItem> {
+  items: T[];
+  remainingQuestions: ReviewQueueQuestion[];
+  skippedItemId: number;
+  skippedItemIds?: number[];
+  skippedQuestionType?: ReviewQuestionType;
+  groupQuestions?: boolean;
+  backToBack?: boolean;
+  maxQuestionGap?: number;
+  questionTypeOrderEnabled?: boolean;
+  questionTypeOrder?: ReviewQuestionType;
+  randomFn?: () => number;
+}
+
+interface RebuildReviewQueueAfterSkipResult {
+  queue: ReviewQueueQuestion[];
+  skippedItemIds: number[];
+}
+
 const SUBJECT_TYPE_FALLBACK_ORDER: Record<SubjectType, number> = {
   radical: 0,
   kanji: 1,
@@ -369,6 +388,15 @@ function getReadingQuestion(itemId: number): ReviewQueueQuestion {
   return { type: "reading", itemId };
 }
 
+function getQuestionByType(
+  questionType: ReviewQuestionType,
+  itemId: number
+): ReviewQueueQuestion {
+  return questionType === "reading"
+    ? getReadingQuestion(itemId)
+    : getMeaningQuestion(itemId);
+}
+
 export function generateReviewQuestions<T extends OrderableReviewItem>(
   items: T[],
   options: { groupQuestions?: boolean } = {}
@@ -508,4 +536,132 @@ export function buildReviewQuestionQueue<T extends OrderableReviewItem>(
     shouldForceQuestionTypeOrder,
     normalizedQuestionTypeOrder
   );
+}
+
+function buildSkippedReviewQuestionTail<T extends OrderableReviewItem>(
+  items: T[],
+  {
+    groupQuestions,
+    maxQuestionGap,
+    questionTypeOrderEnabled,
+    questionTypeOrder,
+    firstQuestionTypeByItemId,
+    randomFn,
+  }: {
+    groupQuestions: boolean;
+    maxQuestionGap: number;
+    questionTypeOrderEnabled: boolean;
+    questionTypeOrder: ReviewQuestionType;
+    firstQuestionTypeByItemId: Map<number, ReviewQuestionType>;
+    randomFn: () => number;
+  }
+): ReviewQueueQuestion[] {
+  const queue: ReviewQueueQuestion[] = [];
+  const batchSize = Math.max(1, Math.floor(maxQuestionGap));
+  const normalizedQuestionTypeOrder =
+    questionTypeOrder === "reading" ? "reading" : "meaning";
+  const shouldForceQuestionTypeOrder = questionTypeOrderEnabled && !groupQuestions;
+
+  for (let startIndex = 0; startIndex < items.length; startIndex += batchSize) {
+    const batch = items.slice(startIndex, startIndex + batchSize);
+    const secondPassQuestions: ReviewQueueQuestion[] = [];
+
+    batch.forEach((item) => {
+      const itemHasReadingQuestion = hasReadingQuestion(item);
+
+      if (groupQuestions || !itemHasReadingQuestion) {
+        queue.push(getMeaningQuestion(item.id));
+        return;
+      }
+
+      const firstQuestionType = shouldForceQuestionTypeOrder
+        ? normalizedQuestionTypeOrder
+        : firstQuestionTypeByItemId.get(item.id) ??
+          (randomFn() < 0.5 ? "meaning" : "reading");
+      const secondQuestionType =
+        firstQuestionType === "meaning" ? "reading" : "meaning";
+
+      queue.push(getQuestionByType(firstQuestionType, item.id));
+      secondPassQuestions.push(getQuestionByType(secondQuestionType, item.id));
+    });
+
+    queue.push(...secondPassQuestions);
+  }
+
+  return queue;
+}
+
+export function rebuildReviewQueueAfterSkip<T extends OrderableReviewItem>({
+  items,
+  remainingQuestions,
+  skippedItemId,
+  skippedItemIds = [],
+  skippedQuestionType,
+  groupQuestions = false,
+  backToBack = false,
+  maxQuestionGap = DEFAULT_MAX_QUESTION_GAP,
+  questionTypeOrderEnabled = false,
+  questionTypeOrder = "meaning",
+  randomFn = Math.random,
+}: RebuildReviewQueueAfterSkipOptions<T>): RebuildReviewQueueAfterSkipResult {
+  const itemById = new Map<number, T>();
+  items.forEach((item) => {
+    itemById.set(item.id, item);
+  });
+
+  const remainingItemIds = new Set(
+    remainingQuestions.map((question) => question.itemId)
+  );
+  const skippedOrder = [
+    ...skippedItemIds.filter((itemId) => itemId !== skippedItemId),
+    skippedItemId,
+  ].filter(
+    (itemId) =>
+      itemById.has(itemId) &&
+      (itemId === skippedItemId || remainingItemIds.has(itemId))
+  );
+  const skippedItemIdSet = new Set(skippedOrder);
+  const firstQuestionTypeByItemId = new Map<number, ReviewQuestionType>();
+
+  remainingQuestions.forEach((question) => {
+    if (
+      skippedItemIdSet.has(question.itemId) &&
+      !firstQuestionTypeByItemId.has(question.itemId)
+    ) {
+      firstQuestionTypeByItemId.set(question.itemId, question.type);
+    }
+  });
+
+  if (skippedQuestionType) {
+    firstQuestionTypeByItemId.set(skippedItemId, skippedQuestionType);
+  }
+
+  const baseQueue = remainingQuestions.filter(
+    (question) => !skippedItemIdSet.has(question.itemId)
+  );
+  const skippedItems = skippedOrder
+    .map((itemId) => itemById.get(itemId))
+    .filter((item): item is T => item !== undefined);
+  const skippedTail = backToBack
+    ? buildReviewQuestionQueue(skippedItems, {
+        groupQuestions,
+        backToBack: true,
+        maxQuestionGap,
+        questionTypeOrderEnabled,
+        questionTypeOrder,
+        randomFn,
+      })
+    : buildSkippedReviewQuestionTail(skippedItems, {
+        groupQuestions,
+        maxQuestionGap,
+        questionTypeOrderEnabled,
+        questionTypeOrder,
+        firstQuestionTypeByItemId,
+        randomFn,
+      });
+
+  return {
+    queue: [...baseQueue, ...skippedTail],
+    skippedItemIds: skippedOrder,
+  };
 }


### PR DESCRIPTION
## Summary

Ported two fixes from the pre-open-source that did not make it into the initial Kakehashi import.

- Fixed subject notes and synonyms saving so stale study material cache data does not overwrite newly saved values.
- Fixed skipped review requeue ordering so meaning and reading questions stay spaced out unless back-to-back mode is enabled.
- Added focused review ordering tests for skipped review behavior.
