### PR TITLE
[Settings] Add over the air update experience options

### DIFF
--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -145,6 +145,9 @@ export default function StudyTab() {
   const homeSrsBreakdownDisplayMode = useSettingsStore(
     (state) => state.homeSrsBreakdownDisplayMode,
   );
+  const otaUpdateExperience = useSettingsStore(
+    (state) => state.otaUpdateExperience,
+  );
   const widgetContentMode = useSettingsStore((state) => state.widgetContentMode);
   const widgetStreakGradient = useSettingsStore(
     (state) => state.widgetStreakGradient,
@@ -415,17 +418,40 @@ export default function StudyTab() {
     return () => subscription?.remove();
   }, []);
 
-  // Check for OTA updates
+  // Check for OTA updates in the background when the selected experience asks
+  // Home to show the update banner.
   useEffect(() => {
+    let isCancelled = false;
+
+    if (otaUpdateExperience !== "background-banner") {
+      setIsUpdateAvailable(false);
+    }
+
     async function checkForUpdates() {
-      if (__DEV__) {
-        // Skip update checks in development
+      if (
+        __DEV__ ||
+        !Updates.isEnabled ||
+        otaUpdateExperience !== "background-banner"
+      ) {
+        setIsUpdateAvailable(false);
         return;
       }
 
       try {
         const update = await Updates.checkForUpdateAsync();
-        if (update.isAvailable) {
+        if (!update.isAvailable && !update.isRollBackToEmbedded) {
+          return;
+        }
+
+        const fetchResult = await Updates.fetchUpdateAsync();
+        const isPendingForReload =
+          fetchResult.isNew || fetchResult.isRollBackToEmbedded;
+
+        if (
+          !isCancelled &&
+          isPendingForReload &&
+          otaUpdateExperience === "background-banner"
+        ) {
           setIsUpdateAvailable(true);
         }
       } catch (error) {
@@ -433,8 +459,11 @@ export default function StudyTab() {
       }
     }
 
-    checkForUpdates();
-  }, []);
+    void checkForUpdates();
+    return () => {
+      isCancelled = true;
+    };
+  }, [otaUpdateExperience]);
 
   useEffect(() => {
     if (!userData?.id) {
@@ -805,13 +834,16 @@ export default function StudyTab() {
 
     try {
       setIsDownloadingUpdate(true);
-      await Updates.fetchUpdateAsync();
       await Updates.reloadAsync({ reloadScreenOptions });
     } catch (error) {
       console.error("Error applying update:", error);
-      setIsDownloadingUpdate(false);
-      // If fetch fails, just reload the app to apply any already downloaded updates
-      await Updates.reloadAsync({ reloadScreenOptions });
+      try {
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync({ reloadScreenOptions });
+      } catch (fallbackError) {
+        console.error("Error fetching update before reload:", fallbackError);
+        setIsDownloadingUpdate(false);
+      }
     }
   };
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -69,6 +69,37 @@ type PendingDeepLinkIntent =
       signature: string;
     };
 
+const OTA_UPDATE_CHECK_TIMEOUT_MS = 1000;
+const OTA_UPDATE_CHECK_TIMED_OUT = { timedOut: true } as const;
+
+function resolveWithUpdateCheckTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T | typeof OTA_UPDATE_CHECK_TIMED_OUT> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      resolve(OTA_UPDATE_CHECK_TIMED_OUT);
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      }
+    );
+  });
+}
+
+function isUpdateCheckTimedOut<T>(
+  result: T | typeof OTA_UPDATE_CHECK_TIMED_OUT
+): result is typeof OTA_UPDATE_CHECK_TIMED_OUT {
+  return result === OTA_UPDATE_CHECK_TIMED_OUT;
+}
+
 function RootLayoutContentInner() {
   const { setIsRunning, setProgress } = useBackgroundTasks();
   const [appIsReady, setAppIsReady] = useState(false);
@@ -99,7 +130,14 @@ function RootLayoutContentInner() {
   const { session, isLoading } = useSession();
   const { theme } = useTheme();
   const router = useRouter();
-  const { gravatarEmail, offlineVocabularyAudioEnabled } = useSettingsStore();
+  const {
+    gravatarEmail,
+    offlineVocabularyAudioEnabled,
+    otaUpdateExperience,
+  } = useSettingsStore();
+  const [settingsHydrated, setSettingsHydrated] = useState(() =>
+    useSettingsStore.persist.hasHydrated()
+  );
   const pendingDeepLinkIntentRef = useRef<PendingDeepLinkIntent | null>(null);
   const pendingIssueNotificationIssueIdRef = useRef<string | null>(null);
   const didCheckInitialUrlRef = useRef(false);
@@ -209,8 +247,34 @@ function RootLayoutContentInner() {
       fontsLoaded,
       hasFontError: Boolean(fontError),
       hasApiToken: Boolean(apiToken),
+      settingsHydrated,
+      otaUpdateExperience,
     });
-  }, [apiToken, fontError, fontsLoaded, isLoading, session]);
+  }, [
+    apiToken,
+    fontError,
+    fontsLoaded,
+    isLoading,
+    otaUpdateExperience,
+    session,
+    settingsHydrated,
+  ]);
+
+  useEffect(() => {
+    if (settingsHydrated) {
+      return;
+    }
+
+    const unsubscribe = useSettingsStore.persist.onFinishHydration(() => {
+      setSettingsHydrated(true);
+    });
+
+    if (useSettingsStore.persist.hasHydrated()) {
+      setSettingsHydrated(true);
+    }
+
+    return unsubscribe;
+  }, [settingsHydrated]);
 
   // Listen for app state changes to update badge when app becomes active
   useEffect(() => {
@@ -588,7 +652,7 @@ function RootLayoutContentInner() {
       return;
     }
 
-    if (!fontGateResolved || isLoading) {
+    if (!fontGateResolved || isLoading || !settingsHydrated) {
       return;
     }
 
@@ -656,9 +720,20 @@ function RootLayoutContentInner() {
       };
 
       const applyStartupUpdateIfAvailable = async (): Promise<boolean> => {
+        if (
+          otaUpdateExperience === "background-next-open" ||
+          otaUpdateExperience === "background-banner"
+        ) {
+          startupDiagnostics.markEvent("prepare.ota.deferred", {
+            mode: otaUpdateExperience,
+          });
+          return false;
+        }
+
         if (__DEV__ || !Updates.isEnabled) {
           startupDiagnostics.markEvent("prepare.ota.skipped", {
             reason: __DEV__ ? "development_mode" : "updates_disabled",
+            mode: otaUpdateExperience,
           });
           return false;
         }
@@ -666,14 +741,32 @@ function RootLayoutContentInner() {
         try {
           setLoaderStatusMessage("Checking for updates...");
 
-          const updateCheck = await runTrackedOperation(
+          const updateCheckPromise = runTrackedOperation(
             "prepare.ota.checkForUpdate",
-            () => Updates.checkForUpdateAsync()
+            () => Updates.checkForUpdateAsync(),
+            { mode: otaUpdateExperience }
           );
+          const updateCheck =
+            otaUpdateExperience === "startup-timeboxed"
+              ? await resolveWithUpdateCheckTimeout(
+                  updateCheckPromise,
+                  OTA_UPDATE_CHECK_TIMEOUT_MS
+                )
+              : await updateCheckPromise;
+
+          if (isUpdateCheckTimedOut(updateCheck)) {
+            startupDiagnostics.markEvent("prepare.ota.checkTimedOut", {
+              timeoutMs: OTA_UPDATE_CHECK_TIMEOUT_MS,
+              mode: otaUpdateExperience,
+            });
+            setLoaderStatusMessage(null);
+            return false;
+          }
 
           startupDiagnostics.markEvent("prepare.ota.checkCompleted", {
             isAvailable: updateCheck.isAvailable,
             isRollBackToEmbedded: updateCheck.isRollBackToEmbedded,
+            mode: otaUpdateExperience,
           });
 
           if (!updateCheck.isAvailable && !updateCheck.isRollBackToEmbedded) {
@@ -685,7 +778,8 @@ function RootLayoutContentInner() {
 
           const fetchResult = await runTrackedOperation(
             "prepare.ota.fetchUpdate",
-            () => Updates.fetchUpdateAsync()
+            () => Updates.fetchUpdateAsync(),
+            { mode: otaUpdateExperience }
           );
           const shouldReloadNow =
             fetchResult.isNew || fetchResult.isRollBackToEmbedded;
@@ -694,6 +788,7 @@ function RootLayoutContentInner() {
             isNew: fetchResult.isNew,
             isRollBackToEmbedded: fetchResult.isRollBackToEmbedded,
             shouldReloadNow,
+            mode: otaUpdateExperience,
           });
 
           if (!shouldReloadNow) {
@@ -717,10 +812,39 @@ function RootLayoutContentInner() {
           console.error("Startup OTA check failed:", error);
           startupDiagnostics.markEvent("prepare.ota.failed", {
             error: error instanceof Error ? error.message : String(error),
+            mode: otaUpdateExperience,
           });
           setLoaderStatusMessage(null);
           return false;
         }
+      };
+
+      const fetchStartupUpdateForNextLaunch = async (): Promise<void> => {
+        if (__DEV__ || !Updates.isEnabled) {
+          startupDiagnostics.markEvent("prepare.ota.backgroundSkipped", {
+            reason: __DEV__ ? "development_mode" : "updates_disabled",
+            mode: otaUpdateExperience,
+          });
+          return;
+        }
+
+        const updateCheck = await Updates.checkForUpdateAsync();
+        startupDiagnostics.markEvent("prepare.ota.backgroundCheckCompleted", {
+          isAvailable: updateCheck.isAvailable,
+          isRollBackToEmbedded: updateCheck.isRollBackToEmbedded,
+          mode: otaUpdateExperience,
+        });
+
+        if (!updateCheck.isAvailable && !updateCheck.isRollBackToEmbedded) {
+          return;
+        }
+
+        const fetchResult = await Updates.fetchUpdateAsync();
+        startupDiagnostics.markEvent("prepare.ota.backgroundFetchCompleted", {
+          isNew: fetchResult.isNew,
+          isRollBackToEmbedded: fetchResult.isRollBackToEmbedded,
+          mode: otaUpdateExperience,
+        });
       };
 
       startupDiagnostics.markEvent("root.prepare.begin", {
@@ -730,6 +854,8 @@ function RootLayoutContentInner() {
         hasSession: Boolean(session),
         fontGateResolved,
         fontGate: fontGateDetailsRef.current,
+        settingsHydrated,
+        otaUpdateExperience,
       });
 
       try {
@@ -779,6 +905,14 @@ function RootLayoutContentInner() {
         const didTriggerReload = await applyStartupUpdateIfAvailable();
         if (didTriggerReload) {
           return;
+        }
+
+        if (otaUpdateExperience === "background-next-open") {
+          runPostLoaderOperation(
+            "prepare.ota.backgroundNextOpen",
+            fetchStartupUpdateForNextLaunch,
+            { mode: otaUpdateExperience }
+          );
         }
 
         const token = session;
@@ -971,11 +1105,13 @@ function RootLayoutContentInner() {
     fontError,
     session,
     isLoading,
+    otaUpdateExperience,
     setUserData,
     setIsRunning,
     setProgress,
     requestAppReady,
     queueOfflineAudioDownloadsForLevel,
+    settingsHydrated,
     theme.backgroundColor,
   ]);
 

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,23 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.69",
+    date: "2026-05-28",
+    changes: [
+      {
+        type: "feature",
+        title: "Choose Your Update Experience",
+        description:
+          "Added an Updates setting so you can choose whether OTA updates block startup, wait only briefly, download for the next app open, or show a Home banner. A few days ago OTA checks became slower; even though that is resolved now, this gives you a fallback if it happens again.",
+        link: {
+          route: "/settings",
+          params: { scrollTo: "updates" },
+          label: "Open Update Settings",
+        },
+      },
+    ],
+  },
+  {
     version: "1.2.68",
     date: "2026-05-25",
     changes: [

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -25,6 +25,7 @@ import { AppearanceSection } from "./sections/AppearanceSection";
 import { ThemeSection } from "./sections/ThemeSection";
 import { WidgetSection } from "./sections/WidgetSection";
 import { NotificationsSection } from "./sections/NotificationsSection";
+import { UpdateExperienceSection } from "./sections/UpdateExperienceSection";
 import { DataStorageSection } from "./sections/DataStorageSection";
 import { LevelRecapSection } from "./sections/LevelRecapSection";
 import { PatreonSupportersSection } from "./sections/PatreonSupportersSection";
@@ -174,6 +175,7 @@ function SettingsScreenContent() {
         <ThemeSection />
         <WidgetSection />
         <NotificationsSection />
+        <UpdateExperienceSection />
         <DataStorageSection />
         <LevelRecapSection />
         <PatreonSupportersSection />

--- a/src/features/settings/sections/UpdateExperienceSection.tsx
+++ b/src/features/settings/sections/UpdateExperienceSection.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { Text, TouchableOpacity, View } from "react-native";
+
+import { useSettingsControllerContext } from "../SettingsControllerContext";
+import { styles } from "../styles";
+import type { OtaUpdateExperience } from "../../../utils/store";
+
+const UPDATE_EXPERIENCE_OPTIONS: {
+  value: OtaUpdateExperience;
+  title: string;
+  description: string;
+  icon: React.ComponentProps<typeof Ionicons>["name"];
+}[] = [
+  {
+    value: "startup-blocking",
+    title: "Update before opening",
+    description: "Check and apply updates before the dashboard loads.",
+    icon: "cloud-download-outline",
+  },
+  {
+    value: "startup-timeboxed",
+    title: "Wait up to 1 second",
+    description:
+      "Start with the current flow, but continue opening the app if the check takes too long.",
+    icon: "timer-outline",
+  },
+  {
+    value: "background-next-open",
+    title: "Update next open",
+    description:
+      "Download updates in the background and apply them the next time you open Kakehashi.",
+    icon: "play-skip-forward-outline",
+  },
+  {
+    value: "background-banner",
+    title: "Show Home banner",
+    description:
+      "Download updates in the background, then show a Home banner. Tapping it reloads Home and may repeat WaniKani calls.",
+    icon: "notifications-outline",
+  },
+];
+
+export function UpdateExperienceSection() {
+  const {
+    otaUpdateExperience,
+    setOtaUpdateExperience,
+    theme,
+    updateSectionOffset,
+  } = useSettingsControllerContext();
+
+  return (
+    <View
+      style={[
+        styles.section,
+        {
+          backgroundColor: theme.cardBackground,
+          borderColor: theme.border,
+        },
+      ]}
+      onLayout={(event) => {
+        updateSectionOffset("updates", event.nativeEvent.layout.y);
+      }}
+    >
+      <Text
+        style={[
+          styles.sectionTitle,
+          { color: theme.textColor, borderBottomColor: theme.border },
+        ]}
+      >
+        Updates
+      </Text>
+
+      {UPDATE_EXPERIENCE_OPTIONS.map((option, index) => {
+        const isSelected = otaUpdateExperience === option.value;
+        const isLast = index === UPDATE_EXPERIENCE_OPTIONS.length - 1;
+
+        return (
+          <TouchableOpacity
+            key={option.value}
+            style={[
+              styles.settingItemColumn,
+              styles.updateExperienceOption,
+              { borderBottomColor: isLast ? "transparent" : theme.border },
+            ]}
+            onPress={() => setOtaUpdateExperience(option.value)}
+            activeOpacity={0.75}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: isSelected }}
+          >
+            <View style={styles.settingRow}>
+              <Ionicons
+                name={option.icon}
+                size={24}
+                color={isSelected ? theme.primary : theme.textSecondary}
+                style={styles.settingIcon}
+              />
+              <View style={styles.settingTextContainer}>
+                <Text style={[styles.settingText, { color: theme.textColor }]}>
+                  {option.title}
+                </Text>
+                <Text
+                  style={[
+                    styles.settingSubtext,
+                    { color: theme.textSecondary },
+                  ]}
+                >
+                  {option.description}
+                </Text>
+              </View>
+              <Ionicons
+                name={isSelected ? "radio-button-on" : "radio-button-off"}
+                size={22}
+                color={isSelected ? theme.primary : theme.textSecondary}
+              />
+            </View>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}

--- a/src/features/settings/styles.ts
+++ b/src/features/settings/styles.ts
@@ -109,6 +109,9 @@ export const styles = StyleSheet.create({
     fontSize: 14,
     marginTop: 2,
   },
+  updateExperienceOption: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
   bunproSurveyModalContent: {
     paddingBottom: 24,
   },

--- a/src/features/settings/useSettingsController.ts
+++ b/src/features/settings/useSettingsController.ts
@@ -295,6 +295,7 @@ type SettingsSectionKey =
   | "theme"
   | "widgets"
   | "notifications"
+  | "updates"
   | "dataStorage"
   | "levelRecap"
   | "patreon"
@@ -320,6 +321,7 @@ const SCROLL_TO_SECTION_KEY_MAP: Record<string, SettingsSectionKey> = {
   vocabContext: "vocabContext",
   subjectLists: "subjectLists",
   levelRecap: "levelRecap",
+  updates: "updates",
   jpdbApiKey: "profile",
   jpdb: "profile",
 };
@@ -499,6 +501,8 @@ export function useSettingsController() {
     setSongsLyricsDefaultStudyMode,
     appleMusicAuthStatus,
     setAppleMusicAuthStatus,
+    otaUpdateExperience,
+    setOtaUpdateExperience,
     lastSeenPatchNotesVersion,
     bunproSurveyCompleted,
     setBunproSurveyCompleted,
@@ -677,6 +681,11 @@ export function useSettingsController() {
       key: "notifications",
       label: "Notifications",
       icon: "notifications-outline",
+    });
+    chips.push({
+      key: "updates",
+      label: "Updates",
+      icon: "cloud-download-outline",
     });
 
     if (showDataStorageSection) {
@@ -2816,6 +2825,7 @@ export function useSettingsController() {
     offlineAudioProgress,
     offlineCacheRefreshInFlightRef,
     offlineVocabularyAudioEnabled,
+    otaUpdateExperience,
     openReminderTimeModal,
     openReviewShortcutModal,
     openSrsProgressionCardModePicker,
@@ -2923,6 +2933,7 @@ export function useSettingsController() {
     setOfflineAudioCacheSizeBytes,
     setOfflineAudioProgress,
     setOfflineVocabularyAudioEnabled,
+    setOtaUpdateExperience,
     setPendingNotifications,
     setPendingSectionScrollRequest,
     setPrioritizeCriticalItems,

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -64,6 +64,11 @@ export type VocabularyAudioVoicePreference =
 export type StudyModePreference = "none" | "wk" | "full";
 export type SrsProgressionCardDisplayMode = "normal" | "compact" | "hidden";
 export type LessonPickerViewMode = "cards" | "list";
+export type OtaUpdateExperience =
+  | "startup-blocking"
+  | "startup-timeboxed"
+  | "background-next-open"
+  | "background-banner";
 
 export type WidgetContentMode = "reviews" | "critical" | "streak";
 export type WidgetStreakGradientPreset =
@@ -126,7 +131,7 @@ export const REVIEW_CHARACTER_FONT_SCALE_MIN = 0.7;
 export const REVIEW_CHARACTER_FONT_SCALE_MAX = 1.2;
 export const REVIEW_CHARACTER_FONT_SCALE_STEP = 0.1;
 const AUTH_STORE_SCHEMA_VERSION = 1;
-const SETTINGS_STORE_SCHEMA_VERSION = 9;
+const SETTINGS_STORE_SCHEMA_VERSION = 10;
 const LEGACY_DEFAULT_HOME_EXTRA_STUDY_MODE_ORDER_V5: ExtraStudyModeId[] = [
   "recent-lessons",
   "random-test",
@@ -276,6 +281,18 @@ function normalizeLessonPickerViewMode(value: unknown): LessonPickerViewMode {
       return value;
     default:
       return "cards";
+  }
+}
+
+function normalizeOtaUpdateExperience(value: unknown): OtaUpdateExperience {
+  switch (value) {
+    case "startup-blocking":
+    case "startup-timeboxed":
+    case "background-next-open":
+    case "background-banner":
+      return value;
+    default:
+      return "startup-blocking";
   }
 }
 
@@ -515,6 +532,7 @@ type SettingsState = {
   myAnimeListUsername: string | null;
   aniListUsername: string | null;
   immersionKitAnimes: string[] | null;
+  otaUpdateExperience: OtaUpdateExperience;
 
   // Notification settings
   showBadgeNotifications: boolean;
@@ -679,6 +697,7 @@ type SettingsState = {
   setMyAnimeListUsername: (username: string | null) => void;
   setAniListUsername: (username: string | null) => void;
   setImmersionKitAnimes: (animes: string[] | null) => void;
+  setOtaUpdateExperience: (experience: OtaUpdateExperience) => void;
   setShowBadgeNotifications: (show: boolean) => void;
   setEnableReviewNotifications: (enable: boolean) => void;
   setDailyReviewReminderEnabled: (enable: boolean) => void;
@@ -818,6 +837,7 @@ export const useSettingsStore = create<SettingsState>()(
       showMnemonicIllustrations: true, // Default to enabled (show radical mnemonic illustrations)
       myAnimeListUsername: null, // No MyAnimeList user configured by default
       aniListUsername: null, // No AniList user configured by default
+      otaUpdateExperience: "startup-blocking", // Default to the existing mandatory startup update flow
       showBadgeNotifications: true, // Default to enabled
       enableReviewNotifications: false, // Default to disabled (requires user consent)
       dailyReviewReminderEnabled: false, // Default to disabled
@@ -1040,6 +1060,8 @@ export const useSettingsStore = create<SettingsState>()(
       setAniListUsername: (username) =>
         set({ aniListUsername: username }),
       setImmersionKitAnimes: (animes) => set({ immersionKitAnimes: animes }),
+      setOtaUpdateExperience: (experience) =>
+        set({ otaUpdateExperience: normalizeOtaUpdateExperience(experience) }),
       setShowBadgeNotifications: (show) =>
         set({ showBadgeNotifications: show }),
       setEnableReviewNotifications: (enable) =>
@@ -1220,6 +1242,7 @@ export const useSettingsStore = create<SettingsState>()(
           customTabOrder?: unknown;
           lessonPickerViewMode?: unknown;
           reviewCharacterFontScale?: unknown;
+          otaUpdateExperience?: unknown;
         };
 
         if (version < 2 && typeof migratedRecord.homeSrsBreakdownDisplayMode !== "string") {
@@ -1317,6 +1340,9 @@ export const useSettingsStore = create<SettingsState>()(
           normalizeReviewCharacterFontScale(
             migratedRecord.reviewCharacterFontScale
           );
+        migratedRecord.otaUpdateExperience = normalizeOtaUpdateExperience(
+          migratedRecord.otaUpdateExperience
+        );
 
         return migrated;
       },


### PR DESCRIPTION
## Summary
- add a persisted setting for choosing the OTA update experience
- support blocking, 1-second timeboxed, next-open, and Home-banner update flows
- add an Updates section to Settings and document the change in patch notes

