### PR TITLE
[Feature] Offline mode

### DIFF
--- a/app/(app)/lessons.tsx
+++ b/app/(app)/lessons.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  Platform,
   StatusBar,
   StyleSheet,
   Text,
@@ -16,6 +17,12 @@ import ReviewQuestionScreen from "../../src/components/ReviewQuestionScreen";
 import { useSession } from "../../src/contexts/AuthContext";
 import { useDashboardData } from "../../src/hooks/useDashboardData";
 import {
+  getPendingProgressAssignmentIds,
+  getPendingProgressCounts,
+  queueProgressAndAttemptSend,
+  syncPendingProgress,
+} from "../../src/services/offlineStudyProgressService";
+import {
   Assignment as ApiAssignment,
   Subject as ApiSubject,
   getAvailableLessons,
@@ -25,7 +32,6 @@ import {
   getSubjects,
   isRateLimitError,
   isUnauthorizedError,
-  startLesson,
 } from "../../src/utils/api";
 import {
   buildReviewQuestionQueue,
@@ -46,6 +52,7 @@ interface LessonItem {
   id: number;
   assignmentId: number;
   subjectId: number;
+  availableAt?: string | null;
   subject: ApiSubject;
   meaningDone: boolean;
   readingDone: boolean;
@@ -197,6 +204,7 @@ export default function LessonsScreen() {
     currentBatch: 0,
     totalBatches: 0,
   });
+  const [pendingLessonCount, setPendingLessonCount] = useState(0);
 
   // Add state for tracking type counts
   const [typeCounts, setTypeCounts] = useState<TypeCounts>({
@@ -235,10 +243,51 @@ export default function LessonsScreen() {
     });
   }, []);
 
+  const refreshPendingLessonCount = useCallback(async () => {
+    try {
+      const counts = await getPendingProgressCounts();
+      setPendingLessonCount(counts.lesson);
+    } catch (error) {
+      console.warn("[Lessons] Failed to load pending lesson queue count:", error);
+    }
+  }, []);
+
   // Load lessons when the component mounts
   useEffect(() => {
     loadLessons();
+    // loadLessons reads the latest settings from this render; making it a
+    // dependency would restart the session setup on every local state change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiToken, isAuthLoading]);
+
+  useEffect(() => {
+    if (isAuthLoading || !apiToken) {
+      setPendingLessonCount(0);
+      return;
+    }
+
+    void syncPendingProgress(apiToken)
+      .catch((error) => {
+        console.warn("[Lessons] Failed to sync pending study progress:", error);
+      })
+      .finally(() => {
+        void refreshPendingLessonCount();
+      });
+  }, [apiToken, isAuthLoading, refreshPendingLessonCount]);
+
+  useEffect(() => {
+    if (isAuthLoading || !apiToken) {
+      setPendingLessonCount(0);
+      return;
+    }
+
+    void refreshPendingLessonCount();
+    const intervalId = setInterval(() => {
+      void refreshPendingLessonCount();
+    }, 10_000);
+
+    return () => clearInterval(intervalId);
+  }, [apiToken, isAuthLoading, refreshPendingLessonCount]);
 
   // Fetch study materials when entering review mode
   useEffect(() => {
@@ -332,8 +381,16 @@ export default function LessonsScreen() {
       const selectedAssignments = lessonsResponse.data.filter(
         (_, index) => !selectedIdSet || selectedIdSet.has(index)
       );
+      const pendingProgressAssignmentIds =
+        await getPendingProgressAssignmentIds().catch(() => ({
+          lesson: new Set<number>(),
+          review: new Set<number>(),
+        }));
+      const availableLessonAssignments = selectedAssignments.filter(
+        (assignment) => !pendingProgressAssignmentIds.lesson.has(assignment.id)
+      );
 
-      if (selectedAssignments.length === 0) {
+      if (availableLessonAssignments.length === 0) {
         Alert.alert(
           "No Lessons Available",
           "There are no lessons available within your current daily limit.",
@@ -372,7 +429,7 @@ export default function LessonsScreen() {
       let subjectsById = new Map<number, ApiSubject>();
 
       if (needsSubjects) {
-        const allSubjectIds = selectedAssignments.map(
+        const allSubjectIds = availableLessonAssignments.map(
           (assignment) => assignment.data.subject_id
         );
 
@@ -390,11 +447,11 @@ export default function LessonsScreen() {
       }
 
       const filteredAssignments = excludeKanaVocabularyFromLessons
-        ? selectedAssignments.filter((assignment) => {
+        ? availableLessonAssignments.filter((assignment) => {
             const subject = subjectsById.get(assignment.data.subject_id);
             return subject?.object !== "kana_vocabulary";
           })
-        : selectedAssignments;
+        : availableLessonAssignments;
 
       if (filteredAssignments.length === 0) {
         Alert.alert(
@@ -468,6 +525,7 @@ export default function LessonsScreen() {
           id: items.length, // Unique ID for this lesson item
           assignmentId: assignment.id,
           subjectId: assignment.data.subject_id,
+          availableAt: assignment.data.available_at ?? null,
           subject: subject,
           meaningDone: false,
           readingDone: false,
@@ -1000,9 +1058,36 @@ export default function LessonsScreen() {
 
     if (isItemComplete && !updatedItems[itemIndex].submitted && apiToken) {
       try {
-        await startLesson(apiToken, updatedItems[itemIndex].assignmentId);
+        const completedAt = new Date();
+        const completedAtIso = completedAt.toISOString();
+        const availableAtMs = Date.parse(
+          updatedItems[itemIndex].availableAt ?? ""
+        );
+        const createdAt =
+          Number.isFinite(availableAtMs) &&
+          completedAt.getTime() <= availableAtMs
+            ? null
+            : completedAtIso;
+
+        const queueResult = await queueProgressAndAttemptSend(apiToken, {
+          assignmentId: updatedItems[itemIndex].assignmentId,
+          subjectId: updatedItems[itemIndex].subjectId,
+          progressType: "lesson",
+          createdAt,
+          availableAt: updatedItems[itemIndex].availableAt ?? null,
+        });
         updatedItems[itemIndex].submitted = true;
+        updatedItems[itemIndex].submissionFailed =
+          !queueResult.response && !queueResult.queued;
         setReviewItems(updatedItems);
+
+        if (queueResult.failure?.isPermissionError) {
+          Alert.alert(
+            "Permission Error",
+            "Your API token doesn't have write permissions. Please update your token in WaniKani settings to allow starting assignments.",
+            [{ text: "OK" }]
+          );
+        }
       } catch (error) {
         console.error("Error starting lesson assignment:", error);
         updatedItems[itemIndex].submissionFailed = true;
@@ -1015,15 +1100,36 @@ export default function LessonsScreen() {
             "Your API token doesn't have write permissions. Please update your token in WaniKani settings to allow starting assignments.",
             [{ text: "OK" }]
           );
-        } else {
-          Alert.alert(
-            "Submission Error",
-            "Failed to start the lesson assignment. Please check your internet connection.",
-            [{ text: "OK" }]
-          );
         }
+      } finally {
+        void refreshPendingLessonCount();
       }
     }
+  };
+
+  const renderPendingLessonSyncBadge = () => {
+    if (pendingLessonCount <= 0) {
+      return null;
+    }
+
+    return (
+      <View style={styles.pendingSyncBadgeContainer} pointerEvents="none">
+        <View
+          style={[
+            styles.pendingSyncBadge,
+            {
+              backgroundColor: theme.cardBackground,
+              borderColor: theme.border,
+            },
+          ]}
+        >
+          <Text style={[styles.pendingSyncBadgeText, { color: theme.textColor }]}>
+            {pendingLessonCount} lesson sync
+            {pendingLessonCount === 1 ? "" : "s"} pending
+          </Text>
+        </View>
+      </View>
+    );
   };
 
   if (isLoading) {
@@ -1038,6 +1144,7 @@ export default function LessonsScreen() {
             Loading lessons...
           </Text>
         </View>
+        {renderPendingLessonSyncBadge()}
       </View>
     );
   }
@@ -1049,56 +1156,59 @@ export default function LessonsScreen() {
 
     return (
       <>
-        <LessonDetailScreen
-          item={currentItem}
-          onNext={handleNextItem}
-          onPrev={handlePrevItem}
-          canGoBack={currentItemIndex > 0}
-          canGoForward={true}
-          progress={{
-            current: currentItemIndex + 1,
-            total: currentBatch.items.length,
-            batchCurrent: currentBatchIndex + 1,
-            batchTotal: lessonBatches.length,
-          }}
-          onExit={() => {
-            Alert.alert(
-              "Exit Lessons",
-              "Are you sure you want to exit? Your progress will be saved, but incomplete lessons won't count.",
-              [
-                { text: "Cancel", style: "cancel" },
-                {
-                  text: "Exit",
-                  onPress: navigateBackToDashboard,
-                },
-              ]
-            );
-          }}
-          relatedSubjects={relatedSubjects}
-          typeCounts={typeCounts}
-          batchItems={currentBatch.items}
-          currentBatchIndex={currentItemIndex}
-          onBatchItemPress={(index) => {
-            setCurrentItemIndex(index);
-          }}
-          onSubjectPress={(subjectId) => {
-            // Navigate to subject detail page
-            router.push(`/subject/${subjectId}`);
-          }}
-          onAddSubjectToList={(subject) => {
-            const label =
-              subject.data?.meanings?.find((meaning: any) => meaning.primary)
-                ?.meaning ||
-              subject.data?.meanings?.[0]?.meaning ||
-              subject.data?.characters ||
-              undefined;
-            setListModalSubject({
-              id: subject.id,
-              type: subject.object,
-              label,
-            });
-          }}
-        />
+        <View style={styles.screenWrapper}>
+          <LessonDetailScreen
+            item={currentItem}
+            onNext={handleNextItem}
+            onPrev={handlePrevItem}
+            canGoBack={currentItemIndex > 0}
+            canGoForward={true}
+            progress={{
+              current: currentItemIndex + 1,
+              total: currentBatch.items.length,
+              batchCurrent: currentBatchIndex + 1,
+              batchTotal: lessonBatches.length,
+            }}
+            onExit={() => {
+              Alert.alert(
+                "Exit Lessons",
+                "Are you sure you want to exit? Your progress will be saved, but incomplete lessons won't count.",
+                [
+                  { text: "Cancel", style: "cancel" },
+                  {
+                    text: "Exit",
+                    onPress: navigateBackToDashboard,
+                  },
+                ]
+              );
+            }}
+            relatedSubjects={relatedSubjects}
+            typeCounts={typeCounts}
+            batchItems={currentBatch.items}
+            currentBatchIndex={currentItemIndex}
+            onBatchItemPress={(index) => {
+              setCurrentItemIndex(index);
+            }}
+            onSubjectPress={(subjectId) => {
+              // Navigate to subject detail page
+              router.push(`/subject/${subjectId}`);
+            }}
+            onAddSubjectToList={(subject) => {
+              const label =
+                subject.data?.meanings?.find((meaning: any) => meaning.primary)
+                  ?.meaning ||
+                subject.data?.meanings?.[0]?.meaning ||
+                subject.data?.characters ||
+                undefined;
+              setListModalSubject({
+                id: subject.id,
+                type: subject.object,
+                label,
+              });
+            }}
+          />
+          {renderPendingLessonSyncBadge()}
+        </View>
 
         <AddToSubjectListsModal
           visible={!!listModalSubject}
@@ -1158,58 +1268,61 @@ export default function LessonsScreen() {
     };
 
     return (
-      <ReviewQuestionScreen
-        item={{ id: currentItem.id, subject: adaptedSubject }}
-        questionType={currentQuestion.type}
-        onAnswer={handleAnswer}
-        onSkip={handleSkip}
-        onExit={() => {
-          Alert.alert(
-            "Exit Lessons",
-            "Are you sure you want to exit? Your progress will be saved, but incomplete lessons won't count.",
-            [
-              { text: "Cancel", style: "cancel" },
-              {
-                text: "Exit",
-                onPress: navigateBackToDashboard,
-              },
-            ]
-          );
-        }}
-        showHeader={true}
-        showBackgroundColor={true}
-        totalItems={reviewItems.length}
-        currentItem={
-          activeQueue.length > 0
-            ? effectiveAnkiGrouping
-              ? reviewItems.length -
-                (activeQueue.length + masterQueue.length - ACTIVE_QUEUE_SIZE)
-              : reviewItems.length * 2 -
-                (activeQueue.length + masterQueue.length - ACTIVE_QUEUE_SIZE)
-            : effectiveAnkiGrouping
-            ? reviewItems.length
-            : reviewItems.length * 2
-        }
-        completedCount={
-          reviewItems.filter(
-            (item) =>
-              (item.meaningDone && item.readingDone) ||
-              (item.meaningDone && isSubjectType(item.subject, "radical")) ||
-              (item.meaningDone &&
-                isSubjectType(item.subject, "vocabulary") &&
-                !item.subject.data.readings)
-          ).length
-        }
-        correctAnswersCount={reviewItems.reduce((count, item) => {
-          let correctCount = 0;
-          if (item.meaningDone) correctCount++;
-          if (item.readingDone) correctCount++;
-          return count + correctCount;
-        }, 0)}
-        isLessonFlow={true}
-        studyMaterials={studyMaterialsMap.get(currentItem.subjectId)}
-        onSynonymAdded={handleSynonymAdded}
-      />
+      <View style={[styles.container, { backgroundColor: theme.backgroundColor }]}>
+        <ReviewQuestionScreen
+          item={{ id: currentItem.id, subject: adaptedSubject }}
+          questionType={currentQuestion.type}
+          onAnswer={handleAnswer}
+          onSkip={handleSkip}
+          onExit={() => {
+            Alert.alert(
+              "Exit Lessons",
+              "Are you sure you want to exit? Your progress will be saved, but incomplete lessons won't count.",
+              [
+                { text: "Cancel", style: "cancel" },
+                {
+                  text: "Exit",
+                  onPress: navigateBackToDashboard,
+                },
+              ]
+            );
+          }}
+          showHeader={true}
+          showBackgroundColor={true}
+          totalItems={reviewItems.length}
+          currentItem={
+            activeQueue.length > 0
+              ? effectiveAnkiGrouping
+                ? reviewItems.length -
+                  (activeQueue.length + masterQueue.length - ACTIVE_QUEUE_SIZE)
+                : reviewItems.length * 2 -
+                  (activeQueue.length + masterQueue.length - ACTIVE_QUEUE_SIZE)
+              : effectiveAnkiGrouping
+              ? reviewItems.length
+              : reviewItems.length * 2
+          }
+          completedCount={
+            reviewItems.filter(
+              (item) =>
+                (item.meaningDone && item.readingDone) ||
+                (item.meaningDone && isSubjectType(item.subject, "radical")) ||
+                (item.meaningDone &&
+                  isSubjectType(item.subject, "vocabulary") &&
+                  !item.subject.data.readings)
+            ).length
+          }
+          correctAnswersCount={reviewItems.reduce((count, item) => {
+            let correctCount = 0;
+            if (item.meaningDone) correctCount++;
+            if (item.readingDone) correctCount++;
+            return count + correctCount;
+          }, 0)}
+          isLessonFlow={true}
+          studyMaterials={studyMaterialsMap.get(currentItem.subjectId)}
+          onSynonymAdded={handleSynonymAdded}
+        />
+        {renderPendingLessonSyncBadge()}
+      </View>
     );
   }
 
@@ -1404,6 +1517,7 @@ export default function LessonsScreen() {
           subjectLabel={`Current lessons (${currentLessonSubjectIds.length})`}
           onClose={() => setShowSaveCurrentLessonsModal(false)}
         />
+        {renderPendingLessonSyncBadge()}
       </View>
     );
   }
@@ -1428,6 +1542,7 @@ export default function LessonsScreen() {
           <Text style={styles.buttonText}>Back to Dashboard</Text>
         </TouchableOpacity>
       </View>
+      {renderPendingLessonSyncBadge()}
     </View>
   );
 }
@@ -1436,6 +1551,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#f6f6f6",
+  },
+  screenWrapper: {
+    flex: 1,
+  },
+  pendingSyncBadgeContainer: {
+    position: "absolute",
+    bottom: Platform.OS === "ios" ? 28 : 20,
+    alignSelf: "center",
+    zIndex: 50,
+  },
+  pendingSyncBadge: {
+    borderRadius: 16,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  pendingSyncBadgeText: {
+    fontSize: 12,
+    fontWeight: "600",
   },
   loadingContainer: {
     flex: 1,

--- a/app/(app)/lessons.tsx
+++ b/app/(app)/lessons.tsx
@@ -22,6 +22,7 @@ import {
   queueProgressAndAttemptSend,
   syncPendingProgress,
 } from "../../src/services/offlineStudyProgressService";
+import { markLessonStartedInAssignmentCaches } from "../../src/services/studyProgressAssignmentCacheService";
 import {
   Assignment as ApiAssignment,
   Subject as ApiSubject,
@@ -1080,6 +1081,18 @@ export default function LessonsScreen() {
         updatedItems[itemIndex].submissionFailed =
           !queueResult.response && !queueResult.queued;
         setReviewItems(updatedItems);
+
+        if (queueResult.response || queueResult.queued) {
+          await markLessonStartedInAssignmentCaches({
+            assignmentId: updatedItems[itemIndex].assignmentId,
+            startedAt: completedAtIso,
+          }).catch((cacheError) => {
+            console.warn(
+              "[Lessons] Failed to update local assignment review time:",
+              cacheError
+            );
+          });
+        }
 
         if (queueResult.failure?.isPermissionError) {
           Alert.alert(

--- a/app/(app)/reviews.tsx
+++ b/app/(app)/reviews.tsx
@@ -1,6 +1,7 @@
 import { router } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useIsFocused } from "@react-navigation/native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import {
   ActivityIndicator,
   Alert,
@@ -16,6 +17,12 @@ import { useSession } from "../../src/contexts/AuthContext";
 import { useDashboardData } from "../../src/hooks/useDashboardData";
 import useBluetoothAudioKeepAlive from "../../src/hooks/useBluetoothAudioKeepAlive";
 import {
+  getPendingProgressAssignmentIds,
+  getPendingProgressCounts,
+  queueProgressAndAttemptSend,
+  syncPendingProgress,
+} from "../../src/services/offlineStudyProgressService";
+import {
   ApiError,
   getAvailableReviews,
   getReviewCount,
@@ -25,7 +32,6 @@ import {
   isRateLimitError,
   isUnauthorizedError,
   Subject,
-  submitReview,
 } from "../../src/utils/api";
 import { errorService } from "../../src/services/errorService";
 import { getAllSubjects } from "../../src/utils/cache";
@@ -68,8 +74,11 @@ interface ReviewItem {
 // Define interface for failed submission
 interface FailedSubmission {
   assignmentId: number;
+  subjectId?: number;
   meaningIncorrect: number;
   readingIncorrect: number;
+  createdAt?: string | null;
+  availableAt?: string | null;
   retryCount: number;
   isPermissionError?: boolean; // Track if failure was due to missing permissions (401)
   statusCode?: number | null;
@@ -146,6 +155,7 @@ export default function ReviewScreen() {
   });
   const [isFinished, setIsFinished] = useState(false);
   const [submittingResults, setSubmittingResults] = useState(false);
+  const [pendingReviewCount, setPendingReviewCount] = useState(0);
   const [reviewPermissionWarning, setReviewPermissionWarning] = useState<
     string | null
   >(null);
@@ -175,6 +185,15 @@ export default function ReviewScreen() {
     autoplayVocabularyAudio && !isLoading && !isFinished && isFocused;
   useBluetoothAudioKeepAlive(shouldKeepReviewAudioWarm, "Reviews");
 
+  const refreshPendingReviewCount = useCallback(async () => {
+    try {
+      const counts = await getPendingProgressCounts();
+      setPendingReviewCount(counts.review);
+    } catch (error) {
+      console.warn("[Reviews] Failed to load pending review queue count:", error);
+    }
+  }, []);
+
   // Handler for when a synonym is added from the review screen
   const handleSynonymAdded = useCallback((subjectId: number, newSynonyms: string[]) => {
     setStudyMaterialsMap(prev => {
@@ -188,6 +207,29 @@ export default function ReviewScreen() {
   const ACTIVE_QUEUE_SIZE = 10; // Number of questions to keep in active queue
   const REFILL_THRESHOLD = 3; // Refill active queue when it has this many items left
   const MAX_SUBMISSION_RETRIES = 3; // Maximum number of times to retry submitting a review
+
+  const resolveProgressCreatedAt = useCallback(
+    (
+      availableAt: string | null | undefined,
+      fallbackCreatedAt?: string | null
+    ): string | null => {
+      const now = new Date();
+      const baseDate =
+        fallbackCreatedAt && !Number.isNaN(Date.parse(fallbackCreatedAt))
+          ? new Date(fallbackCreatedAt)
+          : now;
+      const availableAtMs = availableAt ? Date.parse(availableAt) : NaN;
+
+      // Match Tsurukame semantics: only include created_at when completion is
+      // strictly after assignment.available_at.
+      if (Number.isFinite(availableAtMs) && baseDate.getTime() <= availableAtMs) {
+        return null;
+      }
+
+      return baseDate.toISOString();
+    },
+    []
+  );
   
   // Helper function to get remaining subjects count
   const getRemainingSubjectsCount = useCallback(() => {
@@ -427,6 +469,15 @@ export default function ReviewScreen() {
           const availableAtMs = Date.parse(assignmentData.available_at);
           return Number.isFinite(availableAtMs) && availableAtMs <= now.getTime();
         }
+      );
+      const pendingProgressAssignmentIds =
+        await getPendingProgressAssignmentIds().catch(() => ({
+          lesson: new Set<number>(),
+          review: new Set<number>(),
+        }));
+      availableReviewAssignments = availableReviewAssignments.filter(
+        (assignment: any) =>
+          !pendingProgressAssignmentIds.review.has(assignment.id)
       );
 
       if (availableReviewAssignments.length === 0) {
@@ -987,6 +1038,35 @@ export default function ReviewScreen() {
   };
 
   useEffect(() => {
+    if (isAuthLoading || !apiToken) {
+      setPendingReviewCount(0);
+      return;
+    }
+
+    void syncPendingProgress(apiToken)
+      .catch((error) => {
+        console.warn("[Reviews] Failed to sync pending study progress:", error);
+      })
+      .finally(() => {
+        void refreshPendingReviewCount();
+      });
+  }, [apiToken, isAuthLoading, refreshPendingReviewCount]);
+
+  useEffect(() => {
+    if (isAuthLoading || !apiToken) {
+      setPendingReviewCount(0);
+      return;
+    }
+
+    void refreshPendingReviewCount();
+    const intervalId = setInterval(() => {
+      void refreshPendingReviewCount();
+    }, 10_000);
+
+    return () => clearInterval(intervalId);
+  }, [apiToken, isAuthLoading, refreshPendingReviewCount]);
+
+  useEffect(() => {
     loadReviews().then(() => {
       // Ensure the progress state includes correctAnswersCount
       setProgress((prev) => ({
@@ -1133,22 +1213,57 @@ export default function ReviewScreen() {
     apiToken: string,
     assignmentId: number,
     meaningIncorrect: number,
-    readingIncorrect: number
+    readingIncorrect: number,
+    options: {
+      subjectId?: number;
+      availableAt?: string | null;
+      createdAt?: string | null;
+    } = {}
   ): Promise<SubmissionAttemptResult> => {
     try {
-      // Avoid clock-drift validation failures by relying on server time for
-      // immediate live reviews.
-      const response = (await submitReview(
-        apiToken,
+      const createdAt = resolveProgressCreatedAt(
+        options.availableAt,
+        options.createdAt
+      );
+      const queueResult = await queueProgressAndAttemptSend(apiToken, {
         assignmentId,
-        meaningIncorrect,
-        readingIncorrect
-      )) as ReviewSubmissionResponse;
+        subjectId: options.subjectId,
+        progressType: "review",
+        meaningIncorrectCount: meaningIncorrect,
+        readingIncorrectCount: readingIncorrect,
+        createdAt,
+        availableAt: options.availableAt ?? null,
+      });
+      const response = queueResult.response as ReviewSubmissionResponse | null;
 
-      // Mark that at least one review was submitted (for unmount refresh)
+      if (!response) {
+        if (queueResult.queued) {
+          hasSubmittedReviewsRef.current = true;
+        }
+        if (queueResult.failure?.isPermissionError) {
+          showReviewPermissionWarning();
+        }
+
+        return {
+          response: null,
+          failure: {
+            assignmentId,
+            subjectId: options.subjectId,
+            meaningIncorrect,
+            readingIncorrect,
+            createdAt,
+            availableAt: options.availableAt ?? null,
+            retryCount: 0,
+            isPermissionError: queueResult.failure?.isPermissionError,
+            statusCode: queueResult.failure?.statusCode ?? null,
+            failureReason:
+              queueResult.failure?.message ?? "Unknown review submission error",
+          },
+        };
+      }
+
+      // Mark that at least one review was submitted (for unmount refresh).
       hasSubmittedReviewsRef.current = true;
-
-      // Return the full response for SRS progression display
       return { response };
     } catch (error) {
       const errorObj = error instanceof Error ? error : new Error(String(error));
@@ -1188,14 +1303,19 @@ export default function ReviewScreen() {
         response: null,
         failure: {
           assignmentId,
+          subjectId: options.subjectId,
           meaningIncorrect,
           readingIncorrect,
+          createdAt: options.createdAt ?? null,
+          availableAt: options.availableAt ?? null,
           retryCount: 0,
           isPermissionError,
           statusCode,
           failureReason,
         },
       };
+    } finally {
+      void refreshPendingReviewCount();
     }
   };
 
@@ -1327,13 +1447,22 @@ export default function ReviewScreen() {
 
       // Submit to WaniKani and show SRS card with actual response data
       pendingSubmissionCountRef.current += 1;
+      const createdAt = resolveProgressCreatedAt(
+        updatedItems[itemIndex].availableAt,
+        new Date().toISOString()
+      );
       submitReviewWithRetry(
         apiToken,
         updatedItems[itemIndex].assignmentId,
         updatedItems[itemIndex].meaningIncorrect,
         isRadical || isVocabWithoutReading
           ? 0
-          : updatedItems[itemIndex].readingIncorrect
+          : updatedItems[itemIndex].readingIncorrect,
+        {
+          subjectId: updatedItems[itemIndex].subjectId,
+          availableAt: updatedItems[itemIndex].availableAt ?? null,
+          createdAt,
+        }
       )
         .then(({ response, failure }) => {
           if (response) {
@@ -1544,7 +1673,12 @@ export default function ReviewScreen() {
           apiToken,
           submission.assignmentId,
           submission.meaningIncorrect,
-          submission.readingIncorrect
+          submission.readingIncorrect,
+          {
+            subjectId: submission.subjectId,
+            createdAt: submission.createdAt ?? null,
+            availableAt: submission.availableAt ?? null,
+          }
         );
 
         if (response) {
@@ -1552,8 +1686,11 @@ export default function ReviewScreen() {
         } else {
           remainingSubmissions.push({
             assignmentId: submission.assignmentId,
+            subjectId: submission.subjectId,
             meaningIncorrect: submission.meaningIncorrect,
             readingIncorrect: submission.readingIncorrect,
+            createdAt: submission.createdAt ?? null,
+            availableAt: submission.availableAt ?? null,
             retryCount: submission.retryCount + 1,
             isPermissionError: failure?.isPermissionError,
             statusCode: failure?.statusCode,
@@ -1561,8 +1698,11 @@ export default function ReviewScreen() {
           });
           upsertFailedSubmission({
             assignmentId: submission.assignmentId,
+            subjectId: submission.subjectId,
             meaningIncorrect: submission.meaningIncorrect,
             readingIncorrect: submission.readingIncorrect,
+            createdAt: submission.createdAt ?? null,
+            availableAt: submission.availableAt ?? null,
             retryCount: submission.retryCount + 1,
             isPermissionError: failure?.isPermissionError,
             statusCode: failure?.statusCode,
@@ -1584,8 +1724,11 @@ export default function ReviewScreen() {
 
         remainingSubmissions.push({
           assignmentId: submission.assignmentId,
+          subjectId: submission.subjectId,
           meaningIncorrect: submission.meaningIncorrect,
           readingIncorrect: submission.readingIncorrect,
+          createdAt: submission.createdAt ?? null,
+          availableAt: submission.availableAt ?? null,
           retryCount: submission.retryCount + 1,
           isPermissionError,
           statusCode,
@@ -1652,7 +1795,15 @@ export default function ReviewScreen() {
             apiToken,
             item.assignmentId,
             item.meaningIncorrect,
-            readingIncorrect
+            readingIncorrect,
+            {
+              subjectId: item.subjectId,
+              availableAt: item.availableAt ?? null,
+              createdAt: resolveProgressCreatedAt(
+                item.availableAt ?? null,
+                new Date().toISOString()
+              ),
+            }
           );
 
           if (response) {
@@ -1666,8 +1817,14 @@ export default function ReviewScreen() {
                 ?.retryCount ?? 0;
             const failedSubmission: FailedSubmission = {
               assignmentId: item.assignmentId,
+              subjectId: item.subjectId,
               meaningIncorrect: item.meaningIncorrect,
               readingIncorrect,
+              createdAt: resolveProgressCreatedAt(
+                item.availableAt ?? null,
+                new Date().toISOString()
+              ),
+              availableAt: item.availableAt ?? null,
               retryCount: existingRetryCount + 1,
               isPermissionError: failure?.isPermissionError,
               statusCode: failure?.statusCode,
@@ -1692,6 +1849,21 @@ export default function ReviewScreen() {
           remainingFailures = await retryFailedSubmissions(remainingFailures);
         }
       }
+
+      const pendingSyncResult = await syncPendingProgress(apiToken);
+      if (pendingSyncResult.sent > 0) {
+        hasSubmittedReviewsRef.current = true;
+      }
+      void refreshPendingReviewCount();
+
+      const pendingProgressAssignmentIds =
+        await getPendingProgressAssignmentIds().catch(() => ({
+          lesson: new Set<number>(),
+          review: new Set<number>(),
+        }));
+      remainingFailures = remainingFailures.filter((submission) =>
+        pendingProgressAssignmentIds.review.has(submission.assignmentId)
+      );
 
       setFailedSubmissions(remainingFailures);
 
@@ -1848,6 +2020,37 @@ export default function ReviewScreen() {
     );
   };
 
+  const renderPendingReviewSyncBadge = () => {
+    if (pendingReviewCount <= 0 || isLoading || isFinished) {
+      return null;
+    }
+
+    return (
+      <View style={styles.pendingSyncBadgeContainer} pointerEvents="none">
+        <View
+          style={[
+            styles.pendingSyncBadge,
+            {
+              backgroundColor: theme.cardBackground,
+              borderColor: theme.border,
+            },
+          ]}
+        >
+          <View style={styles.pendingSyncBadgeContent}>
+            <MaterialCommunityIcons
+              name="wifi-off"
+              size={11}
+              color={theme.textSecondary}
+            />
+            <Text style={[styles.pendingSyncBadgeText, { color: theme.textColor }]}>
+              {pendingReviewCount} review{pendingReviewCount === 1 ? "" : "s"}
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  };
+
   if (isLoading) {
     return (
       <View style={[styles.container, { backgroundColor: theme.backgroundColor }]}>
@@ -1856,6 +2059,7 @@ export default function ReviewScreen() {
           <ActivityIndicator size="large" color={theme.secondary} />
           <Text style={[styles.loadingText, { color: theme.textColor }]}>Loading reviews...</Text>
         </View>
+        {renderPendingReviewSyncBadge()}
       </View>
     );
   }
@@ -1874,6 +2078,7 @@ export default function ReviewScreen() {
           onBackToDashboard={handleBackToDashboard}
         />
       )}
+      {renderPendingReviewSyncBadge()}
     </View>
   );
 }
@@ -1895,6 +2100,30 @@ const styles = StyleSheet.create({
   },
   reviewContainer: {
     flex: 1,
+  },
+  pendingSyncBadgeContainer: {
+    position: "absolute",
+    top: 140,
+    alignSelf: "center",
+    zIndex: 50,
+  },
+  pendingSyncBadge: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    minWidth: 82,
+  },
+  pendingSyncBadgeContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+  },
+  pendingSyncBadgeText: {
+    fontSize: 10,
+    fontWeight: "600",
+    textAlign: "center",
   },
   progressContainer: {
     position: "absolute",

--- a/app/(app)/reviews.tsx
+++ b/app/(app)/reviews.tsx
@@ -22,6 +22,7 @@ import {
   queueProgressAndAttemptSend,
   syncPendingProgress,
 } from "../../src/services/offlineStudyProgressService";
+import { markReviewSubmittedInAssignmentCaches } from "../../src/services/studyProgressAssignmentCacheService";
 import {
   ApiError,
   getAvailableReviews,
@@ -79,6 +80,7 @@ interface FailedSubmission {
   readingIncorrect: number;
   createdAt?: string | null;
   availableAt?: string | null;
+  currentSrsStage?: number;
   retryCount: number;
   isPermissionError?: boolean; // Track if failure was due to missing permissions (401)
   statusCode?: number | null;
@@ -1218,6 +1220,7 @@ export default function ReviewScreen() {
       subjectId?: number;
       availableAt?: string | null;
       createdAt?: string | null;
+      currentSrsStage?: number;
     } = {}
   ): Promise<SubmissionAttemptResult> => {
     try {
@@ -1236,6 +1239,25 @@ export default function ReviewScreen() {
       });
       const response = queueResult.response as ReviewSubmissionResponse | null;
 
+      if (response || queueResult.queued) {
+        await markReviewSubmittedInAssignmentCaches({
+          assignmentId,
+          meaningIncorrectCount: meaningIncorrect,
+          readingIncorrectCount: readingIncorrect,
+          completedAt: createdAt ?? new Date().toISOString(),
+          currentSrsStage: options.currentSrsStage,
+          endingSrsStage: response?.data?.ending_srs_stage,
+          nextReviewAt:
+            response?.resources_updated?.assignment?.data?.available_at ??
+            undefined,
+        }).catch((cacheError) => {
+          console.warn(
+            "[Reviews] Failed to update local assignment review time:",
+            cacheError
+          );
+        });
+      }
+
       if (!response) {
         if (queueResult.queued) {
           hasSubmittedReviewsRef.current = true;
@@ -1253,6 +1275,7 @@ export default function ReviewScreen() {
             readingIncorrect,
             createdAt,
             availableAt: options.availableAt ?? null,
+            currentSrsStage: options.currentSrsStage,
             retryCount: 0,
             isPermissionError: queueResult.failure?.isPermissionError,
             statusCode: queueResult.failure?.statusCode ?? null,
@@ -1308,6 +1331,7 @@ export default function ReviewScreen() {
           readingIncorrect,
           createdAt: options.createdAt ?? null,
           availableAt: options.availableAt ?? null,
+          currentSrsStage: options.currentSrsStage,
           retryCount: 0,
           isPermissionError,
           statusCode,
@@ -1462,6 +1486,7 @@ export default function ReviewScreen() {
           subjectId: updatedItems[itemIndex].subjectId,
           availableAt: updatedItems[itemIndex].availableAt ?? null,
           createdAt,
+          currentSrsStage: currentSRSStage,
         }
       )
         .then(({ response, failure }) => {
@@ -1678,6 +1703,7 @@ export default function ReviewScreen() {
             subjectId: submission.subjectId,
             createdAt: submission.createdAt ?? null,
             availableAt: submission.availableAt ?? null,
+            currentSrsStage: submission.currentSrsStage,
           }
         );
 
@@ -1691,6 +1717,7 @@ export default function ReviewScreen() {
             readingIncorrect: submission.readingIncorrect,
             createdAt: submission.createdAt ?? null,
             availableAt: submission.availableAt ?? null,
+            currentSrsStage: submission.currentSrsStage,
             retryCount: submission.retryCount + 1,
             isPermissionError: failure?.isPermissionError,
             statusCode: failure?.statusCode,
@@ -1703,6 +1730,7 @@ export default function ReviewScreen() {
             readingIncorrect: submission.readingIncorrect,
             createdAt: submission.createdAt ?? null,
             availableAt: submission.availableAt ?? null,
+            currentSrsStage: submission.currentSrsStage,
             retryCount: submission.retryCount + 1,
             isPermissionError: failure?.isPermissionError,
             statusCode: failure?.statusCode,
@@ -1729,6 +1757,7 @@ export default function ReviewScreen() {
           readingIncorrect: submission.readingIncorrect,
           createdAt: submission.createdAt ?? null,
           availableAt: submission.availableAt ?? null,
+          currentSrsStage: submission.currentSrsStage,
           retryCount: submission.retryCount + 1,
           isPermissionError,
           statusCode,
@@ -1803,6 +1832,7 @@ export default function ReviewScreen() {
                 item.availableAt ?? null,
                 new Date().toISOString()
               ),
+              currentSrsStage: item.srsStage,
             }
           );
 
@@ -1825,6 +1855,7 @@ export default function ReviewScreen() {
                 new Date().toISOString()
               ),
               availableAt: item.availableAt ?? null,
+              currentSrsStage: item.srsStage,
               retryCount: existingRetryCount + 1,
               isPermissionError: failure?.isPermissionError,
               statusCode: failure?.statusCode,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ import { MusicPlayerProvider } from "../src/contexts/MusicPlayerContext";
 import { DashboardProvider } from "../src/hooks/useDashboardData";
 import { analyticsService } from "../src/services/analyticsService";
 import { featureFlagsService } from "../src/services/featureFlagsService";
+import { syncPendingProgress } from "../src/services/offlineStudyProgressService";
 import { queueOfflineVocabularyAudioDownloads } from "../src/services/offlineVocabularyAudioService";
 import { getAllSubjectsFromAPI, getUserData } from "../src/utils/api";
 import {
@@ -314,6 +315,9 @@ function RootLayoutContentInner() {
         if (!shouldUseNativeReviewNotificationSystem()) {
           tasks.push(updateLastReviewCount());
         }
+        if (apiToken) {
+          tasks.push(syncPendingProgress(apiToken));
+        }
 
         if (userData?.id) {
           tasks.push(
@@ -342,7 +346,7 @@ function RootLayoutContentInner() {
       }
       subscription?.remove();
     };
-  }, [userData?.id, userData?.username, userData?.level]);
+  }, [apiToken, userData?.id, userData?.username, userData?.level]);
 
   // Initialize global error handlers
   useEffect(() => {
@@ -935,6 +939,12 @@ function RootLayoutContentInner() {
         runPostLoaderOperation("prepare.initializeAzureSpeech.background", () =>
           azureSpeechService.initialize()
         );
+
+        if (token) {
+          runPostLoaderOperation("prepare.syncPendingProgress.background", () =>
+            syncPendingProgress(token)
+          );
+        }
 
         // If we have a token, try to load user data and start fast path
         if (token) {

--- a/src/components/HomeDashboardWidget.tsx
+++ b/src/components/HomeDashboardWidget.tsx
@@ -129,7 +129,7 @@ export default function HomeDashboardWidget({
       });
     }
 
-    return dashboardData.assignments.filter((assignment: any) => {
+    const filteredCount = dashboardData.assignments.filter((assignment: any) => {
       if (
         !assignment?.data?.unlocked_at ||
         assignment.data.started_at ||
@@ -141,6 +141,8 @@ export default function HomeDashboardWidget({
       const subjectType = subjectTypeById.get(assignment.data.subject_id);
       return subjectType !== "kana_vocabulary";
     }).length;
+
+    return Math.min(filteredCount, dashboardData.lessonCount);
   }, [
     dashboardData.assignments,
     dashboardData.lessonCount,
@@ -317,6 +319,8 @@ export default function HomeDashboardWidget({
           lessonCount={effectiveLessonCount}
           totalLessonCount={availableLessonCountBeforeDailyLimit}
           reviewCount={dashboardData.reviewCount}
+          pendingLessonSyncCount={dashboardData.pendingLessonSyncCount ?? 0}
+          pendingReviewSyncCount={dashboardData.pendingReviewSyncCount ?? 0}
           currentLevel={dashboardData.currentLevel}
           subjects={dashboardData.subjects}
           assignments={dashboardData.assignments}

--- a/src/components/LessonsReviewsCard.tsx
+++ b/src/components/LessonsReviewsCard.tsx
@@ -25,6 +25,7 @@ const isTablet = screenWidth > 768;
 type LessonsReviewsCardProps = {
   type: "lessons" | "reviews";
   count: number;
+  pendingSyncCount?: number;
   totalLessonCount?: number; // Total available lessons before daily-cap filtering
   onPress: () => void;
   onLessonPicker?: () => void; // Optional callback for lesson picker
@@ -40,6 +41,7 @@ type LessonsReviewsCardProps = {
 export default function LessonsReviewsCard({
   type,
   count,
+  pendingSyncCount: pendingSyncCountProp = 0,
   totalLessonCount,
   onPress,
   onLessonPicker,
@@ -71,21 +73,31 @@ export default function LessonsReviewsCard({
     (state) => state.widgetReviewCardGradientEnd
   );
   const isLessons = type === "lessons";
+  const pendingSyncCount = Math.max(0, pendingSyncCountProp);
+  // Dashboard counts already exclude pending offline progress IDs.
+  const displayCount = Math.max(0, count);
   const followsTheme = isLessons
     ? widgetLessonCardFollowTheme
     : widgetReviewCardFollowTheme;
-  const totalAvailableLessons = isLessons ? totalLessonCount ?? count : count;
+  const totalAvailableLessons = isLessons
+    ? Math.max(0, totalLessonCount ?? count)
+    : displayCount;
   const lessonsBlockedByDailyLimit =
-    isLessons && Boolean(isDailyLimitReached) && count === 0;
+    isLessons && Boolean(isDailyLimitReached) && displayCount === 0;
   const canShowLessonPicker =
     isLessons && Boolean(onLessonPicker) && totalAvailableLessons > 0;
   const isGrayedOut =
     (isLessons && (Boolean(isDone) || Boolean(isDailyLimitReached))) ||
-    count === 0;
+    displayCount === 0;
+  const pendingSyncLabel = pendingSyncCount
+    ? `${pendingSyncCount} ${isLessons ? "lesson" : "review"}${
+        pendingSyncCount === 1 ? "" : "s"
+      } awaiting sync`
+    : null;
   const hasCriticalReviews = React.useMemo(() => {
     if (
       isLessons ||
-      !count ||
+      !displayCount ||
       !currentLevel ||
       !Array.isArray(subjects) ||
       !Array.isArray(assignments) ||
@@ -127,7 +139,7 @@ export default function LessonsReviewsCard({
         assignment.data.srs_stage <= 4
       );
     });
-  }, [assignments, count, currentLevel, isLessons, subjects]);
+  }, [assignments, currentLevel, displayCount, isLessons, subjects]);
   const reviewCountBadgeBorderColor =
     !isLessons && hasCriticalReviews
       ? themeMode === "sepia"
@@ -236,7 +248,7 @@ export default function LessonsReviewsCard({
         { shadowColor: theme.isDark ? "#000000" : "#000000" },
       ]}
       onPress={onPress}
-      disabled={count === 0 || lessonsBlockedByDailyLimit}
+      disabled={displayCount === 0 || lessonsBlockedByDailyLimit}
       activeOpacity={0.9}
     >
       <LinearGradient
@@ -249,21 +261,21 @@ export default function LessonsReviewsCard({
         {isLessons ? (
           <Image
             source={
-              count === 0
+              displayCount === 0
                 ? require("../../assets/images/NoLessons.png")
                 : require("../../assets/images/Lessons.png")
             }
             style={[
               styles.backgroundImage,
               !isTablet && styles.backgroundImageMobile,
-              count === 0 && styles.noLessonsImage,
+              displayCount === 0 && styles.noLessonsImage,
             ]}
             resizeMode="contain"
           />
         ) : (
           <Image
             source={
-              count === 0
+              displayCount === 0
                 ? require("../../assets/images/ReviewsFinished.png")
                 : require("../../assets/images/Reviews.png")
             }
@@ -305,7 +317,7 @@ export default function LessonsReviewsCard({
                 ]}
               >
                 <Text style={[styles.countText, { color: theme.textColor }]}>
-                  {count}
+                  {displayCount}
                 </Text>
               </View>
             </View>
@@ -328,19 +340,26 @@ export default function LessonsReviewsCard({
               : "Review these items to level them up!"}
           </Text>
 
+          {pendingSyncLabel ? (
+            <View style={styles.pendingSyncRow}>
+              <Ionicons name="cloud-upload-outline" size={14} color="white" />
+              <Text style={styles.pendingSyncText}>{pendingSyncLabel}</Text>
+            </View>
+          ) : null}
+
           <View style={styles.bottomRow}>
             {lessonsBlockedByDailyLimit ? (
               <View style={styles.blockedLessonsContainer}>
                 <Text style={styles.nextTimeText}>More lessons unlock tomorrow.</Text>
                 {renderLessonPickerButton()}
               </View>
-            ) : isLessons && count === 0 ? (
+            ) : isLessons && displayCount === 0 ? (
               <Text style={styles.nextTimeText}>
                 {nextLessonTime
                   ? formatNextTime(nextLessonTime)
                   : "No lessons available right now."}
               </Text>
-            ) : !isLessons && count === 0 && nextReviewTime ? (
+            ) : !isLessons && displayCount === 0 && nextReviewTime ? (
               <Text style={styles.nextTimeText}>
                 {formatNextTime(nextReviewTime)}
               </Text>
@@ -384,6 +403,8 @@ export function LessonsReviewsCardPair({
   lessonCount,
   totalLessonCount,
   reviewCount,
+  pendingLessonSyncCount = 0,
+  pendingReviewSyncCount = 0,
   onLessonsPress,
   onReviewsPress,
   onLessonPicker,
@@ -399,6 +420,8 @@ export function LessonsReviewsCardPair({
   lessonCount: number;
   totalLessonCount?: number;
   reviewCount: number;
+  pendingLessonSyncCount?: number;
+  pendingReviewSyncCount?: number;
   onLessonsPress: () => void;
   onReviewsPress: () => void;
   onLessonPicker?: () => void;
@@ -421,6 +444,7 @@ export function LessonsReviewsCardPair({
       <LessonsReviewsCard
         type="lessons"
         count={lessonCount}
+        pendingSyncCount={pendingLessonSyncCount}
         totalLessonCount={totalLessonCount}
         onPress={onLessonsPress}
         onLessonPicker={onLessonPicker}
@@ -431,6 +455,7 @@ export function LessonsReviewsCardPair({
       <LessonsReviewsCard
         type="reviews"
         count={reviewCount}
+        pendingSyncCount={pendingReviewSyncCount}
         onPress={onReviewsPress}
         nextReviewTime={nextReviewTime}
         currentLevel={currentLevel}
@@ -575,5 +600,16 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     alignItems: "flex-start",
     gap: 8,
+  },
+  pendingSyncRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  pendingSyncText: {
+    fontSize: 12,
+    color: "white",
+    opacity: 0.95,
+    fontWeight: "600",
   },
 });

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.70",
+    date: "2026-05-29",
+    changes: [
+      {
+        type: "feature",
+        title: "Offline Lessons and Reviews",
+        description:
+          "Lessons and reviews now keep working without a connection. Progress is saved locally, synced when you're back online.",
+      },
+    ],
+  },
+  {
     version: "1.2.69",
     date: "2026-05-28",
     changes: [

--- a/src/hooks/useDashboardData.tsx
+++ b/src/hooks/useDashboardData.tsx
@@ -28,16 +28,19 @@ import {
   getResets,
   getRecentLessonAssignments,
   getRecentReviewStatistics,
+  getReviewCount,
   getReviewForecast,
   getReviewStatisticsOptimized,
   getSubjects,
   getSummary,
   getUserData,
+  isAssignmentInLessonQueueState,
   isAssignmentInReviewQueueState,
   type Assignment,
   type CollectionResponse,
   type VisibleReviewData,
 } from "../utils/api";
+import { getPendingProgressAssignmentIds } from "../services/offlineStudyProgressService";
 import { apiDebugger } from "../utils/apiDebugger";
 import { getSubjectById, prefetchSubjectsByLevel } from "../utils/cache";
 import { getDashboardCache, saveDashboardCache } from "../utils/dashboardCache";
@@ -91,6 +94,8 @@ type DashboardDataType = {
   srsStagesTotal: number;
   nextLessonDate: string | null;
   nextReviewDate: string | null;
+  pendingLessonSyncCount: number;
+  pendingReviewSyncCount: number;
   recentLessonCount: number;
   learnedKanjiCount: number;
   levelTimeRemaining: {
@@ -131,6 +136,8 @@ const initialDashboardData: DashboardDataType = {
   srsStagesTotal: 0,
   nextLessonDate: null,
   nextReviewDate: null,
+  pendingLessonSyncCount: 0,
+  pendingReviewSyncCount: 0,
   recentLessonCount: 0,
   learnedKanjiCount: 0,
   levelTimeRemaining: {
@@ -162,6 +169,76 @@ interface DashboardContextType {
   isFreshData: boolean;
 }
 
+type LessonAndReviewCounts = {
+  lessonCount: number;
+  reviewCount: number;
+  nextLessonDate: string | null;
+  nextReviewDate: string | null;
+};
+
+type PendingProgressAssignmentIds = {
+  lesson: Set<number>;
+  review: Set<number>;
+};
+
+const EMPTY_PENDING_PROGRESS_ASSIGNMENT_IDS: PendingProgressAssignmentIds = {
+  lesson: new Set<number>(),
+  review: new Set<number>(),
+};
+
+function getLessonAndReviewCountsFromAssignments(
+  assignmentsData: any[],
+  pendingProgressAssignmentIds: PendingProgressAssignmentIds = EMPTY_PENDING_PROGRESS_ASSIGNMENT_IDS
+): LessonAndReviewCounts {
+  const now = new Date();
+  const assignmentsExcludingPendingReviews =
+    pendingProgressAssignmentIds.review.size > 0
+      ? assignmentsData.filter(
+          (assignment) => !pendingProgressAssignmentIds.review.has(assignment.id)
+        )
+      : assignmentsData;
+  const visibleReviewData = buildVisibleReviewDataFromAssignments(
+    assignmentsExcludingPendingReviews,
+    { now }
+  );
+  const lessonAssignments = assignmentsData.filter((assignment) => {
+    if (pendingProgressAssignmentIds.lesson.has(assignment.id)) {
+      return false;
+    }
+    return isAssignmentInLessonQueueState(assignment?.data);
+  });
+
+  const lessonCount = lessonAssignments.length;
+  const reviewCount = visibleReviewData.currentReviews;
+
+  let nextLessonDate: string | null = null;
+  let nextReviewDate: string | null = null;
+
+  if (reviewCount === 0) {
+    const upcomingReviews = assignmentsData
+      .filter((assignment) => {
+        if (!isAssignmentInReviewQueueState(assignment?.data)) {
+          return false;
+        }
+        if (pendingProgressAssignmentIds.review.has(assignment.id)) {
+          return false;
+        }
+        return new Date(assignment.data.available_at).getTime() > now.getTime();
+      })
+      .sort(
+        (leftAssignment, rightAssignment) =>
+          new Date(leftAssignment.data.available_at).getTime() -
+          new Date(rightAssignment.data.available_at).getTime()
+      );
+
+    if (upcomingReviews.length > 0) {
+      nextReviewDate = upcomingReviews[0].data.available_at;
+    }
+  }
+
+  return { lessonCount, reviewCount, nextLessonDate, nextReviewDate };
+}
+
 const DashboardContext = createContext<DashboardContextType>({
   dashboardData: initialDashboardData,
   isLoading: false,
@@ -191,9 +268,30 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const dashboardBackgroundRefreshInFlightRef = useRef(false);
   const lessonsReviewsRefreshInFlightRef = useRef<Promise<void> | null>(null);
   const recentMistakesRefreshInFlightRef = useRef<Promise<void> | null>(null);
+  const pendingSyncCountsRefreshInFlightRef = useRef(false);
+  const pendingSyncLastTotalRef = useRef(0);
+  const pendingSyncTriggeredRefreshInFlightRef = useRef(false);
 
   // Calculate loading progress based on current stage
   const loadingProgress = loadingStage / TOTAL_LOADING_STAGES;
+
+  const loadPendingProgressAssignmentIds = useCallback(
+    async (): Promise<PendingProgressAssignmentIds> => {
+      try {
+        return await getPendingProgressAssignmentIds();
+      } catch (error) {
+        console.warn(
+          "[Dashboard] Failed to load pending progress assignment IDs:",
+          error
+        );
+        return {
+          lesson: new Set<number>(),
+          review: new Set<number>(),
+        };
+      }
+    },
+    []
+  );
 
   const getLessonAndReviewCountsFromSummary = (summary: any) => {
     const nowMs = Date.now();
@@ -226,6 +324,64 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       nextReviewDate: summary?.data?.next_reviews_at ?? null,
     };
   };
+
+  const reconcileReviewCountWithVisibleEndpoint = useCallback(
+    async (
+      token: string,
+      assignments: CollectionResponse<Assignment>,
+      counts: LessonAndReviewCounts
+    ): Promise<{
+      assignments: CollectionResponse<Assignment>;
+      counts: LessonAndReviewCounts;
+    }> => {
+      try {
+        const visibleReviewCount = await getReviewCount(token);
+
+        if (visibleReviewCount === counts.reviewCount) {
+          return { assignments, counts };
+        }
+
+        console.warn(
+          `[Dashboard] Review count mismatch (assignments=${counts.reviewCount}, visible=${visibleReviewCount}). Running full assignments refresh...`
+        );
+
+        const fullAssignments = await getAssignmentsOptimized(
+          token,
+          {},
+          { forceFullRefresh: true }
+        );
+        const refreshedCounts = getLessonAndReviewCountsFromAssignments(
+          fullAssignments.data
+        );
+
+        if (refreshedCounts.reviewCount === visibleReviewCount) {
+          return {
+            assignments: fullAssignments,
+            counts: refreshedCounts,
+          };
+        }
+
+        console.warn(
+          `[Dashboard] Review count mismatch persisted after full refresh (full=${refreshedCounts.reviewCount}, visible=${visibleReviewCount}). Using visible count for UI consistency.`
+        );
+
+        return {
+          assignments: fullAssignments,
+          counts: {
+            ...refreshedCounts,
+            reviewCount: visibleReviewCount,
+          },
+        };
+      } catch (error) {
+        console.warn(
+          "[Dashboard] Failed to reconcile review count with visible endpoint:",
+          error
+        );
+        return { assignments, counts };
+      }
+    },
+    []
+  );
 
   // Process assignments to get counts for lessons and reviews
   const processAssignments = useCallback(
@@ -303,12 +459,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           (await getAssignmentsOptimized(token, {}, {
             forceFullRefresh: shouldForceAssignmentsFullRefresh,
           }));
+        const pendingProgressAssignmentIds =
+          await loadPendingProgressAssignmentIds();
 
-        // Process lesson and review counts from the assignments data
-        let counts = getLessonAndReviewCounts(assignments.data);
+        // Process server-aligned counts first for reconciliation logic.
+        let serverCounts = getLessonAndReviewCountsFromAssignments(assignments.data);
         const shouldReconcileLessonCountMismatch =
           !shouldForceAssignmentsFullRefresh &&
-          summaryCounts.lessonCount > counts.lessonCount;
+          summaryCounts.lessonCount > serverCounts.lessonCount;
 
         if (shouldReconcileLessonCountMismatch) {
           try {
@@ -318,7 +476,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               { forceFullRefresh: true }
             );
             assignments = fullAssignments;
-            counts = getLessonAndReviewCounts(fullAssignments.data);
+            serverCounts = getLessonAndReviewCountsFromAssignments(
+              fullAssignments.data
+            );
           } catch (fullRefreshError) {
             console.warn(
               "[Dashboard] Failed full assignments refresh after lesson count mismatch:",
@@ -326,6 +486,17 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             );
           }
         }
+
+        ({ assignments, counts: serverCounts } =
+          await reconcileReviewCountWithVisibleEndpoint(
+            token,
+            assignments,
+            serverCounts
+          ));
+        const counts = getLessonAndReviewCountsFromAssignments(
+          assignments.data,
+          pendingProgressAssignmentIds
+        );
 
         // Save assignments to permanent storage (survives iOS cache clearing)
         try {
@@ -341,12 +512,18 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         }
 
         // Update with more accurate assignment-based counts
+        const latestPendingProgressAssignmentIdsForCounts =
+          await loadPendingProgressAssignmentIds();
         setDashboardData((prev) => ({
           ...prev,
           lessonCount: counts.lessonCount,
           reviewCount: counts.reviewCount,
           nextLessonDate: counts.nextLessonDate,
           nextReviewDate: counts.nextReviewDate,
+          pendingLessonSyncCount:
+            latestPendingProgressAssignmentIdsForCounts.lesson.size,
+          pendingReviewSyncCount:
+            latestPendingProgressAssignmentIdsForCounts.review.size,
           dataLoadingState: { ...prev.dataLoadingState, assignments: true },
         }));
 
@@ -734,11 +911,17 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         }));
 
         // CRITICAL: Final update with subjects and assignments arrays AND subjects-dependent data
+        const latestPendingProgressAssignmentIdsForFinalSnapshot =
+          await loadPendingProgressAssignmentIds();
         setDashboardData((prev) => ({
           ...prev,
           subjects: allSubjects,
           assignments: assignments.data,
           learnedKanjiCount,
+          pendingLessonSyncCount:
+            latestPendingProgressAssignmentIdsForFinalSnapshot.lesson.size,
+          pendingReviewSyncCount:
+            latestPendingProgressAssignmentIdsForFinalSnapshot.review.size,
           dataLoadingState: { ...prev.dataLoadingState, subjects: true },
         }));
 
@@ -763,6 +946,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           srsStagesTotal,
           nextLessonDate: counts.nextLessonDate,
           nextReviewDate: counts.nextReviewDate,
+          pendingLessonSyncCount:
+            latestPendingProgressAssignmentIdsForFinalSnapshot.lesson.size,
+          pendingReviewSyncCount:
+            latestPendingProgressAssignmentIdsForFinalSnapshot.review.size,
           recentLessonCount,
           learnedKanjiCount,
           levelTimeRemaining: levelTimeRemainingData,
@@ -784,54 +971,16 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         throw error;
       }
     },
-    [setLearnedKanjiCount, setUserData]
+    // generateForecast* callbacks are declared later in this component and are
+    // stable; processAssignments is only invoked after render has completed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      loadPendingProgressAssignmentIds,
+      reconcileReviewCountWithVisibleEndpoint,
+      setLearnedKanjiCount,
+      setUserData,
+    ]
   );
-
-  // Helper function to extract lesson and review counts from assignments
-  // This allows us to refresh just these counts without fetching all other data
-  const getLessonAndReviewCounts = (assignmentsData: any[]) => {
-    // Calculate the actual number of lessons and reviews available right now
-    const now = new Date();
-    const visibleReviewData = buildVisibleReviewDataFromAssignments(
-      assignmentsData,
-      { now }
-    );
-    const lessonAssignments = assignmentsData.filter(
-      (a) =>
-        a.data.unlocked_at &&
-        !a.data.started_at &&
-        !a.data.hidden
-    );
-
-    const lessonCount = lessonAssignments.length;
-    const reviewCount = visibleReviewData.currentReviews;
-
-    // Find the next lesson and review time
-    let nextLessonDate: string | null = null;
-    let nextReviewDate: string | null = null;
-
-    // If no reviews are available, find the next available review time
-    if (reviewCount === 0) {
-      const upcomingReviews = assignmentsData
-        .filter((a) => {
-          if (!isAssignmentInReviewQueueState(a?.data)) {
-            return false;
-          }
-          return new Date(a.data.available_at).getTime() > now.getTime();
-        })
-        .sort(
-          (a, b) =>
-            new Date(a.data.available_at).getTime() -
-            new Date(b.data.available_at).getTime()
-        );
-
-      if (upcomingReviews.length > 0) {
-        nextReviewDate = upcomingReviews[0].data.available_at;
-      }
-    }
-
-    return { lessonCount, reviewCount, nextLessonDate, nextReviewDate };
-  };
 
   const syncReviewNotificationState = useCallback(
     async (visibleReviewData: VisibleReviewData | null) => {
@@ -1492,13 +1641,17 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           const cachedData = await getDashboardCache();
           if (cachedData) {
             usedCachedDashboard = true;
+            const pendingProgressAssignmentIdsForCachedData =
+              await loadPendingProgressAssignmentIds();
             const normalizedCachedData =
               Array.isArray((cachedData as any).assignments) &&
               (cachedData as any).assignments.length > 0
                 ? (() => {
-                    const normalizedCounts = getLessonAndReviewCounts(
-                      (cachedData as any).assignments
-                    );
+                    const normalizedCounts =
+                      getLessonAndReviewCountsFromAssignments(
+                        (cachedData as any).assignments,
+                        pendingProgressAssignmentIdsForCachedData
+                      );
                     return {
                       ...cachedData,
                       lessonCount: normalizedCounts.lessonCount,
@@ -1509,9 +1662,19 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
                       nextReviewDate:
                         normalizedCounts.nextReviewDate ??
                         (cachedData as any).nextReviewDate,
+                      pendingLessonSyncCount:
+                        pendingProgressAssignmentIdsForCachedData.lesson.size,
+                      pendingReviewSyncCount:
+                        pendingProgressAssignmentIdsForCachedData.review.size,
                     };
                   })()
-                : cachedData;
+                : {
+                    ...cachedData,
+                    pendingLessonSyncCount:
+                      pendingProgressAssignmentIdsForCachedData.lesson.size,
+                    pendingReviewSyncCount:
+                      pendingProgressAssignmentIdsForCachedData.review.size,
+                  };
             // Use cached data immediately
             setDashboardData(normalizedCachedData);
             setIsFreshData(false);
@@ -1527,7 +1690,31 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
                 ((cachedData as any).subjects?.length ?? 0) === 0 ||
                 ((cachedData as any).assignments?.length ?? 0) === 0;
               if (reconstructed && needsInflation) {
-                setDashboardData(reconstructed);
+                const normalizedCounts = Array.isArray(reconstructed.assignments)
+                  ? getLessonAndReviewCountsFromAssignments(
+                      reconstructed.assignments,
+                      pendingProgressAssignmentIdsForCachedData
+                    )
+                  : null;
+                setDashboardData({
+                  ...reconstructed,
+                  lessonCount:
+                    normalizedCounts?.lessonCount ?? reconstructed.lessonCount ?? 0,
+                  reviewCount:
+                    normalizedCounts?.reviewCount ?? reconstructed.reviewCount ?? 0,
+                  nextLessonDate:
+                    normalizedCounts?.nextLessonDate ??
+                    reconstructed.nextLessonDate ??
+                    null,
+                  nextReviewDate:
+                    normalizedCounts?.nextReviewDate ??
+                    reconstructed.nextReviewDate ??
+                    null,
+                  pendingLessonSyncCount:
+                    pendingProgressAssignmentIdsForCachedData.lesson.size,
+                  pendingReviewSyncCount:
+                    pendingProgressAssignmentIdsForCachedData.review.size,
+                });
               }
             } catch (inflateError) {
               console.warn("Offline reconstruction failed:", inflateError);
@@ -1598,15 +1785,31 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             );
 
             try {
-              const latestAssignments = await getAssignmentsOptimized(
+              let latestAssignments = await getAssignmentsOptimized(
                 apiToken,
                 {},
                 { forceFullRefresh: false }
               );
+              const pendingProgressAssignmentIds =
+                await loadPendingProgressAssignmentIds();
+              let serverCounts = getLessonAndReviewCountsFromAssignments(
+                latestAssignments.data
+              );
+              ({
+                assignments: latestAssignments,
+                counts: serverCounts,
+              } = await reconcileReviewCountWithVisibleEndpoint(
+                apiToken,
+                latestAssignments,
+                serverCounts
+              ));
               preloadedAssignments = latestAssignments;
 
               const { lessonCount, reviewCount, nextLessonDate, nextReviewDate } =
-                getLessonAndReviewCounts(latestAssignments.data);
+                getLessonAndReviewCountsFromAssignments(
+                  latestAssignments.data,
+                  pendingProgressAssignmentIds
+                );
 
               setDashboardData((prevData) => ({
                 ...prevData,
@@ -1614,6 +1817,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
                 reviewCount,
                 nextLessonDate,
                 nextReviewDate,
+                pendingLessonSyncCount: pendingProgressAssignmentIds.lesson.size,
+                pendingReviewSyncCount: pendingProgressAssignmentIds.review.size,
                 assignments: latestAssignments.data,
                 dataLoadingState: {
                   ...prevData.dataLoadingState,
@@ -1622,7 +1827,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               }));
 
               void syncReviewNotificationState(
-                buildVisibleReviewDataFromAssignments(latestAssignments.data)
+                buildVisibleReviewDataFromAssignments(
+                  pendingProgressAssignmentIds.review.size > 0
+                    ? latestAssignments.data.filter(
+                        (assignment) =>
+                          !pendingProgressAssignmentIds.review.has(assignment.id)
+                      )
+                    : latestAssignments.data
+                )
               );
 
               startupDiagnostics.endOperation(fastCountsOperationId, {
@@ -1668,8 +1880,17 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
                 if (freshData) {
                   setIsFreshData(true);
                   await saveDashboardCache(freshData);
+                  const pendingProgressAssignmentIds =
+                    await loadPendingProgressAssignmentIds();
                   void syncReviewNotificationState(
-                    buildVisibleReviewDataFromAssignments(freshData.assignments)
+                    buildVisibleReviewDataFromAssignments(
+                      pendingProgressAssignmentIds.review.size > 0
+                        ? freshData.assignments.filter(
+                            (assignment) =>
+                              !pendingProgressAssignmentIds.review.has(assignment.id)
+                          )
+                        : freshData.assignments
+                    )
                   );
                 }
                 startupDiagnostics.endOperation(backgroundRefreshOperationId, {
@@ -1687,7 +1908,39 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
                   const reconstructed =
                     await getFullDashboardDataFromPermanentStorage();
                   if (reconstructed) {
-                    setDashboardData(reconstructed);
+                    const pendingProgressAssignmentIdsForReconstructedData =
+                      await loadPendingProgressAssignmentIds();
+                    const normalizedCounts = Array.isArray(
+                      reconstructed.assignments
+                    )
+                      ? getLessonAndReviewCountsFromAssignments(
+                          reconstructed.assignments,
+                          pendingProgressAssignmentIdsForReconstructedData
+                        )
+                      : null;
+                    setDashboardData({
+                      ...reconstructed,
+                      lessonCount:
+                        normalizedCounts?.lessonCount ??
+                        reconstructed.lessonCount ??
+                        0,
+                      reviewCount:
+                        normalizedCounts?.reviewCount ??
+                        reconstructed.reviewCount ??
+                        0,
+                      nextLessonDate:
+                        normalizedCounts?.nextLessonDate ??
+                        reconstructed.nextLessonDate ??
+                        null,
+                      nextReviewDate:
+                        normalizedCounts?.nextReviewDate ??
+                        reconstructed.nextReviewDate ??
+                        null,
+                      pendingLessonSyncCount:
+                        pendingProgressAssignmentIdsForReconstructedData.lesson.size,
+                      pendingReviewSyncCount:
+                        pendingProgressAssignmentIdsForReconstructedData.review.size,
+                    });
                   }
                 } catch (offlineError) {
                   console.warn(
@@ -1723,8 +1976,17 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
           // Cache the fresh data
           await saveDashboardCache(finalData);
+          const pendingProgressAssignmentIds =
+            await loadPendingProgressAssignmentIds();
           void syncReviewNotificationState(
-            buildVisibleReviewDataFromAssignments(finalData.assignments)
+            buildVisibleReviewDataFromAssignments(
+              pendingProgressAssignmentIds.review.size > 0
+                ? finalData.assignments.filter(
+                    (assignment) =>
+                      !pendingProgressAssignmentIds.review.has(assignment.id)
+                  )
+                : finalData.assignments
+            )
           );
 
           // Prefetch subjects for current level and next level for instant navigation
@@ -1757,9 +2019,35 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
         // Try permanent storage fallback for offline functionality
         try {
+          const pendingProgressAssignmentIdsForOfflineData =
+            await loadPendingProgressAssignmentIds();
           const offlineData = await getFullDashboardDataFromPermanentStorage();
           if (offlineData) {
-            setDashboardData(offlineData);
+            const normalizedCounts = Array.isArray(offlineData.assignments)
+              ? getLessonAndReviewCountsFromAssignments(
+                  offlineData.assignments,
+                  pendingProgressAssignmentIdsForOfflineData
+                )
+              : null;
+            setDashboardData({
+              ...offlineData,
+              lessonCount:
+                normalizedCounts?.lessonCount ?? offlineData.lessonCount ?? 0,
+              reviewCount:
+                normalizedCounts?.reviewCount ?? offlineData.reviewCount ?? 0,
+              nextLessonDate:
+                normalizedCounts?.nextLessonDate ??
+                offlineData.nextLessonDate ??
+                null,
+              nextReviewDate:
+                normalizedCounts?.nextReviewDate ??
+                offlineData.nextReviewDate ??
+                null,
+              pendingLessonSyncCount:
+                pendingProgressAssignmentIdsForOfflineData.lesson.size,
+              pendingReviewSyncCount:
+                pendingProgressAssignmentIdsForOfflineData.review.size,
+            });
             setIsFreshData(false);
             setErrorStatus(
               "Using offline data. Some information may be outdated."
@@ -1834,7 +2122,13 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         }
       }
     },
-    [apiToken, processAssignments, syncReviewNotificationState]
+    [
+      apiToken,
+      loadPendingProgressAssignmentIds,
+      processAssignments,
+      reconcileReviewCountWithVisibleEndpoint,
+      syncReviewNotificationState,
+    ]
   );
 
   // Add a function to refresh just the lessons and reviews counts
@@ -1855,6 +2149,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
     const refreshPromise = (async () => {
       let notificationReviewData: VisibleReviewData | null = null;
+      let pendingProgressAssignmentIds: PendingProgressAssignmentIds =
+        EMPTY_PENDING_PROGRESS_ASSIGNMENT_IDS;
 
       try {
         setIsLoading(true);
@@ -1866,23 +2162,27 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           {},
           { forceFullRefresh: false }
         );
-        let counts = getLessonAndReviewCounts(assignments.data);
+        let serverCounts = getLessonAndReviewCountsFromAssignments(
+          assignments.data
+        );
 
         // If incremental sync returns an unexpectedly tiny lesson count, confirm
         // against summary and recover with a full refresh when needed.
-        if (counts.lessonCount <= 1) {
+        if (serverCounts.lessonCount <= 1) {
           try {
             const summary = await getSummary(apiToken, { forceRefresh: false });
             const summaryCounts = getLessonAndReviewCountsFromSummary(summary);
 
-            if (summaryCounts.lessonCount > counts.lessonCount) {
+            if (summaryCounts.lessonCount > serverCounts.lessonCount) {
               const fullAssignments = await getAssignmentsOptimized(
                 apiToken,
                 {},
                 { forceFullRefresh: true }
               );
               assignments = fullAssignments;
-              counts = getLessonAndReviewCounts(fullAssignments.data);
+              serverCounts = getLessonAndReviewCountsFromAssignments(
+                fullAssignments.data
+              );
             }
           } catch (summaryReconciliationError) {
             console.warn(
@@ -1892,8 +2192,25 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           }
         }
 
+        ({ assignments, counts: serverCounts } =
+          await reconcileReviewCountWithVisibleEndpoint(
+            apiToken,
+            assignments,
+            serverCounts
+          ));
+        pendingProgressAssignmentIds = await loadPendingProgressAssignmentIds();
+        const counts = getLessonAndReviewCountsFromAssignments(
+          assignments.data,
+          pendingProgressAssignmentIds
+        );
+
         notificationReviewData = buildVisibleReviewDataFromAssignments(
-          assignments.data
+          pendingProgressAssignmentIds.review.size > 0
+            ? assignments.data.filter(
+                (assignment) =>
+                  !pendingProgressAssignmentIds.review.has(assignment.id)
+              )
+            : assignments.data
         );
 
         // Calculate updated counts
@@ -1911,6 +2228,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           reviewCount,
           nextLessonDate,
           nextReviewDate,
+          pendingLessonSyncCount: pendingProgressAssignmentIds.lesson.size,
+          pendingReviewSyncCount: pendingProgressAssignmentIds.review.size,
           assignments: assignments.data,
           forecast: refreshedForecast,
         }));
@@ -1923,6 +2242,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           reviewCount,
           nextLessonDate,
           nextReviewDate,
+          pendingLessonSyncCount: pendingProgressAssignmentIds.lesson.size,
+          pendingReviewSyncCount: pendingProgressAssignmentIds.review.size,
           assignments: assignments.data,
           forecast: refreshedForecast,
         };
@@ -1945,13 +2266,22 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
         // Try permanent storage fallback
         try {
+          pendingProgressAssignmentIds = await loadPendingProgressAssignmentIds();
           const offlineData = await getFullDashboardDataFromPermanentStorage();
           if (offlineData && offlineData.assignments) {
             notificationReviewData = buildVisibleReviewDataFromAssignments(
-              offlineData.assignments
+              pendingProgressAssignmentIds.review.size > 0
+                ? offlineData.assignments.filter(
+                    (assignment: any) =>
+                      !pendingProgressAssignmentIds.review.has(assignment.id)
+                  )
+                : offlineData.assignments
             );
             const { lessonCount, reviewCount, nextLessonDate, nextReviewDate } =
-              getLessonAndReviewCounts(offlineData.assignments);
+              getLessonAndReviewCountsFromAssignments(
+                offlineData.assignments,
+                pendingProgressAssignmentIds
+              );
             const refreshedForecast = rebuildForecastFromAssignments(
               offlineData.assignments,
               offlineData.subjects ?? dashboardDataRef.current.subjects
@@ -1963,6 +2293,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               reviewCount,
               nextLessonDate,
               nextReviewDate,
+              pendingLessonSyncCount: pendingProgressAssignmentIds.lesson.size,
+              pendingReviewSyncCount: pendingProgressAssignmentIds.review.size,
               assignments: offlineData.assignments,
               forecast: refreshedForecast,
             }));
@@ -1973,6 +2305,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               reviewCount,
               nextLessonDate,
               nextReviewDate,
+              pendingLessonSyncCount: pendingProgressAssignmentIds.lesson.size,
+              pendingReviewSyncCount: pendingProgressAssignmentIds.review.size,
               assignments: offlineData.assignments,
               forecast: refreshedForecast,
             };
@@ -2011,7 +2345,80 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         lessonsReviewsRefreshInFlightRef.current = null;
       }
     }
-  }, [apiToken, rebuildForecastFromAssignments, syncReviewNotificationState]);
+  }, [
+    apiToken,
+    loadPendingProgressAssignmentIds,
+    rebuildForecastFromAssignments,
+    reconcileReviewCountWithVisibleEndpoint,
+    syncReviewNotificationState,
+  ]);
+
+  useEffect(() => {
+    if (!apiToken) {
+      pendingSyncLastTotalRef.current = 0;
+      setDashboardData((prevData) => ({
+        ...prevData,
+        pendingLessonSyncCount: 0,
+        pendingReviewSyncCount: 0,
+      }));
+      return;
+    }
+
+    let isActive = true;
+
+    const refreshPendingSyncCounts = async () => {
+      if (pendingSyncCountsRefreshInFlightRef.current) {
+        return;
+      }
+      pendingSyncCountsRefreshInFlightRef.current = true;
+
+      try {
+        const pendingProgressAssignmentIds =
+          await loadPendingProgressAssignmentIds();
+        if (!isActive) {
+          return;
+        }
+
+        const pendingLessonSyncCount = pendingProgressAssignmentIds.lesson.size;
+        const pendingReviewSyncCount = pendingProgressAssignmentIds.review.size;
+        const pendingTotal = pendingLessonSyncCount + pendingReviewSyncCount;
+        const previousPendingTotal = pendingSyncLastTotalRef.current;
+        const pendingQueueShrank = pendingTotal < previousPendingTotal;
+
+        pendingSyncLastTotalRef.current = pendingTotal;
+
+        setDashboardData((prevData) => ({
+          ...prevData,
+          pendingLessonSyncCount,
+          pendingReviewSyncCount,
+        }));
+
+        if (
+          pendingQueueShrank &&
+          !pendingSyncTriggeredRefreshInFlightRef.current
+        ) {
+          pendingSyncTriggeredRefreshInFlightRef.current = true;
+          try {
+            await refreshLessonsAndReviews();
+          } finally {
+            pendingSyncTriggeredRefreshInFlightRef.current = false;
+          }
+        }
+      } finally {
+        pendingSyncCountsRefreshInFlightRef.current = false;
+      }
+    };
+
+    void refreshPendingSyncCounts();
+    const intervalId = setInterval(() => {
+      void refreshPendingSyncCounts();
+    }, 5000);
+
+    return () => {
+      isActive = false;
+      clearInterval(intervalId);
+    };
+  }, [apiToken, loadPendingProgressAssignmentIds, refreshLessonsAndReviews]);
 
   // Lightweight refresh for the Recent Mistakes card (review statistics only).
   const refreshRecentMistakes = useCallback(async () => {
@@ -2114,6 +2521,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     startupDashboardFetchTrackedRef.current = false;
     dashboardForegroundFetchInFlightRef.current = false;
     dashboardBackgroundRefreshInFlightRef.current = false;
+    pendingSyncCountsRefreshInFlightRef.current = false;
+    pendingSyncLastTotalRef.current = 0;
+    pendingSyncTriggeredRefreshInFlightRef.current = false;
     setDashboardData(initialDashboardData);
     setIsFreshData(false);
     setErrorStatus(null);

--- a/src/services/__tests__/offlineStudyProgressService.test.ts
+++ b/src/services/__tests__/offlineStudyProgressService.test.ts
@@ -1,0 +1,328 @@
+type ProgressType = "lesson" | "review";
+
+type PendingRow = {
+  id: number;
+  assignment_id: number;
+  subject_id: number | null;
+  progress_type: ProgressType;
+  meaning_incorrect_count: number;
+  reading_incorrect_count: number;
+  created_at: string | null;
+  available_at: string | null;
+  retry_count: number;
+  inserted_at: number;
+  updated_at: number;
+  last_error: string | null;
+};
+
+class FakeSQLiteDatabase {
+  private rows: PendingRow[] = [];
+  private nextId = 1;
+
+  async execAsync(_sql: string): Promise<void> {
+    // No-op for tests.
+  }
+
+  async runAsync(sql: string, ...args: any[]): Promise<void> {
+    if (sql.includes("INSERT INTO pending_progress")) {
+      const [
+        assignmentId,
+        subjectId,
+        progressType,
+        meaningIncorrectCount,
+        readingIncorrectCount,
+        createdAt,
+        availableAt,
+        insertedAt,
+        updatedAt,
+      ] = args as [
+        number,
+        number | null,
+        ProgressType,
+        number,
+        number,
+        string | null,
+        string | null,
+        number,
+        number
+      ];
+
+      const existingIndex = this.rows.findIndex(
+        (row) =>
+          row.assignment_id === assignmentId && row.progress_type === progressType
+      );
+
+      if (existingIndex >= 0) {
+        const existing = this.rows[existingIndex];
+        this.rows[existingIndex] = {
+          ...existing,
+          subject_id: subjectId,
+          meaning_incorrect_count: meaningIncorrectCount,
+          reading_incorrect_count: readingIncorrectCount,
+          created_at: createdAt,
+          available_at: availableAt,
+          updated_at: updatedAt,
+          last_error: null,
+        };
+        return;
+      }
+
+      this.rows.push({
+        id: this.nextId++,
+        assignment_id: assignmentId,
+        subject_id: subjectId,
+        progress_type: progressType,
+        meaning_incorrect_count: meaningIncorrectCount,
+        reading_incorrect_count: readingIncorrectCount,
+        created_at: createdAt,
+        available_at: availableAt,
+        retry_count: 0,
+        inserted_at: insertedAt,
+        updated_at: updatedAt,
+        last_error: null,
+      });
+      return;
+    }
+
+    if (sql.includes("DELETE FROM pending_progress WHERE id = ?")) {
+      const [id] = args as [number];
+      this.rows = this.rows.filter((row) => row.id !== id);
+      return;
+    }
+
+    if (
+      sql.includes("UPDATE pending_progress") &&
+      sql.includes("retry_count = retry_count + 1")
+    ) {
+      const [updatedAt, lastError, id] = args as [number, string, number];
+      this.rows = this.rows.map((row) =>
+        row.id === id
+          ? {
+              ...row,
+              retry_count: row.retry_count + 1,
+              updated_at: updatedAt,
+              last_error: lastError,
+            }
+          : row
+      );
+      return;
+    }
+
+    throw new Error(`Unhandled runAsync query: ${sql}`);
+  }
+
+  async getFirstAsync<T>(sql: string, ...args: any[]): Promise<T | null> {
+    if (sql.includes("WHERE assignment_id = ? AND progress_type = ?")) {
+      const [assignmentId, progressType] = args as [number, ProgressType];
+      const row = this.rows.find(
+        (candidate) =>
+          candidate.assignment_id === assignmentId &&
+          candidate.progress_type === progressType
+      );
+      return (row ?? null) as T | null;
+    }
+
+    if (sql.includes("SUM(CASE WHEN progress_type = 'lesson'")) {
+      const lessonCount = this.rows.filter(
+        (row) => row.progress_type === "lesson"
+      ).length;
+      const reviewCount = this.rows.filter(
+        (row) => row.progress_type === "review"
+      ).length;
+
+      return {
+        lesson_count: lessonCount,
+        review_count: reviewCount,
+        total_count: this.rows.length,
+      } as T;
+    }
+
+    throw new Error(`Unhandled getFirstAsync query: ${sql}`);
+  }
+
+  async getAllAsync<T>(sql: string, ...args: any[]): Promise<T[]> {
+    if (sql.includes("SELECT assignment_id, progress_type FROM pending_progress")) {
+      return this.rows.map((row) => ({
+        assignment_id: row.assignment_id,
+        progress_type: row.progress_type,
+      })) as T[];
+    }
+
+    if (sql.includes("FROM pending_progress") && sql.includes("ORDER BY inserted_at ASC")) {
+      const sorted = [...this.rows].sort((a, b) => {
+        if (a.inserted_at !== b.inserted_at) {
+          return a.inserted_at - b.inserted_at;
+        }
+        return a.id - b.id;
+      });
+
+      if (sql.includes("LIMIT ?")) {
+        const [limit] = args as [number];
+        return sorted.slice(0, limit) as T[];
+      }
+
+      return sorted as T[];
+    }
+
+    throw new Error(`Unhandled getAllAsync query: ${sql}`);
+  }
+}
+
+class MockApiError extends Error {
+  statusCode: number;
+
+  constructor(statusCode: number, message?: string) {
+    super(message ?? `API error: ${statusCode}`);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+  }
+}
+
+describe("offlineStudyProgressService", () => {
+  const loadModule = () => {
+    jest.resetModules();
+
+    const db = new FakeSQLiteDatabase();
+    const startLessonMock = jest.fn();
+    const submitReviewMock = jest.fn();
+
+    jest.doMock("expo-sqlite", () => ({
+      openDatabaseAsync: jest.fn(async () => db),
+    }));
+
+    jest.doMock("../../utils/api", () => ({
+      ApiError: MockApiError,
+      startLesson: startLessonMock,
+      submitReview: submitReviewMock,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const service = require("../offlineStudyProgressService");
+
+    return {
+      service,
+      startLessonMock,
+      submitReviewMock,
+    };
+  };
+
+  it("sends lesson progress immediately and leaves queue empty on success", async () => {
+    const { service, startLessonMock } = loadModule();
+
+    startLessonMock.mockResolvedValue({ ok: true });
+
+    const result = await service.queueProgressAndAttemptSend("token", {
+      assignmentId: 42,
+      subjectId: 1001,
+      progressType: "lesson",
+    });
+
+    expect(result.response).toEqual({ ok: true });
+    expect(result.queued).toBe(false);
+    expect(startLessonMock).toHaveBeenCalledWith("token", 42, undefined);
+
+    const counts = await service.getPendingProgressCounts();
+    expect(counts).toEqual({ lesson: 0, review: 0, total: 0 });
+  });
+
+  it("keeps review progress queued on network failure and sends it during sync", async () => {
+    const { service, submitReviewMock } = loadModule();
+
+    submitReviewMock
+      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockResolvedValueOnce({ ok: true });
+
+    const queueResult = await service.queueProgressAndAttemptSend("token", {
+      assignmentId: 99,
+      subjectId: 2001,
+      progressType: "review",
+      meaningIncorrectCount: 2,
+      readingIncorrectCount: 1,
+      createdAt: "2026-04-22T12:00:00.000Z",
+      availableAt: "2026-04-22T11:00:00.000Z",
+    });
+
+    expect(queueResult.response).toBeNull();
+    expect(queueResult.queued).toBe(true);
+    expect(queueResult.failure?.reason).toBe("network");
+
+    const beforeSyncCounts = await service.getPendingProgressCounts();
+    expect(beforeSyncCounts.review).toBe(1);
+
+    const syncResult = await service.syncPendingProgress("token");
+    expect(syncResult).toMatchObject({
+      processed: 1,
+      sent: 1,
+      droppedValidation: 0,
+      remaining: 0,
+      stoppedOnFailure: false,
+    });
+
+    const afterSyncCounts = await service.getPendingProgressCounts();
+    expect(afterSyncCounts.total).toBe(0);
+  });
+
+  it("drops queued review progress on replay when API returns 422", async () => {
+    const { service, submitReviewMock } = loadModule();
+
+    submitReviewMock
+      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockRejectedValueOnce(new MockApiError(422, "unprocessable"));
+
+    const queueResult = await service.queueProgressAndAttemptSend("token", {
+      assignmentId: 123,
+      progressType: "review",
+      meaningIncorrectCount: 0,
+      readingIncorrectCount: 0,
+    });
+
+    expect(queueResult.queued).toBe(true);
+
+    const syncResult = await service.syncPendingProgress("token");
+    expect(syncResult).toMatchObject({
+      processed: 1,
+      sent: 0,
+      droppedValidation: 1,
+      remaining: 0,
+      stoppedOnFailure: false,
+    });
+
+    const counts = await service.getPendingProgressCounts();
+    expect(counts.total).toBe(0);
+  });
+
+  it("stops sync on the first non-validation error and keeps remaining queue", async () => {
+    const { service, submitReviewMock } = loadModule();
+
+    submitReviewMock
+      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockRejectedValueOnce(new Error("Network request failed"))
+      .mockRejectedValueOnce(new Error("Network request failed"));
+
+    await service.queueProgressAndAttemptSend("token", {
+      assignmentId: 201,
+      progressType: "review",
+      meaningIncorrectCount: 1,
+      readingIncorrectCount: 0,
+    });
+
+    await service.queueProgressAndAttemptSend("token", {
+      assignmentId: 202,
+      progressType: "review",
+      meaningIncorrectCount: 0,
+      readingIncorrectCount: 1,
+    });
+
+    const syncResult = await service.syncPendingProgress("token");
+    expect(syncResult).toMatchObject({
+      processed: 1,
+      sent: 0,
+      droppedValidation: 0,
+      remaining: 2,
+      stoppedOnFailure: true,
+    });
+
+    const pendingIds = await service.getPendingProgressAssignmentIds();
+    expect(Array.from(pendingIds.review).sort()).toEqual([201, 202]);
+  });
+});

--- a/src/services/__tests__/studyProgressAssignmentCacheService.test.ts
+++ b/src/services/__tests__/studyProgressAssignmentCacheService.test.ts
@@ -1,0 +1,152 @@
+const makeAssignment = (overrides: Partial<any> = {}) => ({
+  id: 42,
+  object: "assignment",
+  url: "https://api.wanikani.com/v2/assignments/42",
+  data_updated_at: "2026-05-28T08:00:00.000Z",
+  data: {
+    created_at: "2026-05-28T08:00:00.000Z",
+    subject_id: 1001,
+    subject_type: "kanji",
+    srs_stage: 0,
+    unlocked_at: "2026-05-28T08:00:00.000Z",
+    started_at: null,
+    passed_at: null,
+    burned_at: null,
+    available_at: null,
+    resurrected_at: null,
+    hidden: false,
+    ...overrides,
+  },
+});
+
+describe("studyProgressAssignmentCacheService", () => {
+  const loadModule = (initialAssignment = makeAssignment()) => {
+    jest.resetModules();
+
+    let asyncCollection: any = {
+      object: "collection",
+      url: "https://api.wanikani.com/v2/assignments",
+      pages: {
+        per_page: 500,
+        next_url: null,
+        previous_url: null,
+      },
+      total_count: 1,
+      data_updated_at: "2026-05-28T08:00:00.000Z",
+      data: [initialAssignment],
+    };
+    let permanentAssignments: any[] = [initialAssignment];
+
+    const saveToCacheMock = jest.fn(async (_key, data) => {
+      asyncCollection = data;
+    });
+    const saveAssignmentsToPermanentStorageMock = jest.fn(
+      async (assignments) => {
+        permanentAssignments = assignments;
+      }
+    );
+
+    jest.doMock("../../utils/cache", () => ({
+      getFromCache: jest.fn(async () => ({
+        data: asyncCollection,
+        timestamp: Date.now(),
+        dataUpdatedAt: asyncCollection.data_updated_at,
+      })),
+      saveToCache: saveToCacheMock,
+    }));
+
+    jest.doMock("../../utils/permanentStorage", () => ({
+      PERMANENT_KEYS: {
+        ALL_ASSIGNMENTS: "assignments_all",
+      },
+      getFromPermanentStorage: jest.fn(async () => ({
+        data: permanentAssignments,
+        timestamp: Date.now(),
+        dataUpdatedAt: "2026-05-28T08:00:00.000Z",
+      })),
+      saveAssignmentsToPermanentStorage:
+        saveAssignmentsToPermanentStorageMock,
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const service = require("../studyProgressAssignmentCacheService");
+
+    return {
+      service,
+      getAsyncAssignment: () => asyncCollection.data[0],
+      getPermanentAssignment: () => permanentAssignments[0],
+      saveToCacheMock,
+      saveAssignmentsToPermanentStorageMock,
+    };
+  };
+
+  it("marks an offline lesson as started and schedules the first review", async () => {
+    const { service, getAsyncAssignment, getPermanentAssignment } = loadModule();
+
+    await service.markLessonStartedInAssignmentCaches({
+      assignmentId: 42,
+      startedAt: "2026-05-28T10:00:00.000Z",
+    });
+
+    expect(getAsyncAssignment().data.started_at).toBe(
+      "2026-05-28T10:00:00.000Z"
+    );
+    expect(getAsyncAssignment().data.srs_stage).toBe(1);
+    expect(getAsyncAssignment().data.available_at).toBe(
+      "2026-05-28T14:00:00.000Z"
+    );
+    expect(getPermanentAssignment().data.available_at).toBe(
+      "2026-05-28T14:00:00.000Z"
+    );
+  });
+
+  it("moves an offline review forward to the next SRS interval", async () => {
+    const { service, getAsyncAssignment } = loadModule(
+      makeAssignment({
+        srs_stage: 1,
+        started_at: "2026-05-28T10:00:00.000Z",
+        available_at: "2026-05-28T14:00:00.000Z",
+      })
+    );
+
+    await service.markReviewSubmittedInAssignmentCaches({
+      assignmentId: 42,
+      meaningIncorrectCount: 0,
+      readingIncorrectCount: 0,
+      completedAt: "2026-05-28T14:05:00.000Z",
+      currentSrsStage: 1,
+    });
+
+    expect(getAsyncAssignment().data.srs_stage).toBe(2);
+    expect(getAsyncAssignment().data.available_at).toBe(
+      "2026-05-28T22:05:00.000Z"
+    );
+  });
+
+  it("uses exact API review timing when a live response is available", async () => {
+    const { service, getAsyncAssignment } = loadModule(
+      makeAssignment({
+        srs_stage: 4,
+        started_at: "2026-05-28T10:00:00.000Z",
+        available_at: "2026-05-30T09:00:00.000Z",
+      })
+    );
+
+    await service.markReviewSubmittedInAssignmentCaches({
+      assignmentId: 42,
+      meaningIncorrectCount: 0,
+      readingIncorrectCount: 0,
+      completedAt: "2026-05-30T09:01:00.000Z",
+      endingSrsStage: 5,
+      nextReviewAt: "2026-06-06T09:01:00.000Z",
+    });
+
+    expect(getAsyncAssignment().data.srs_stage).toBe(5);
+    expect(getAsyncAssignment().data.available_at).toBe(
+      "2026-06-06T09:01:00.000Z"
+    );
+    expect(getAsyncAssignment().data.passed_at).toBe(
+      "2026-05-30T09:01:00.000Z"
+    );
+  });
+});

--- a/src/services/offlineStudyProgressService.ts
+++ b/src/services/offlineStudyProgressService.ts
@@ -1,0 +1,525 @@
+import * as SQLite from "expo-sqlite";
+import {
+  ApiError,
+  startLesson,
+  submitReview,
+} from "../utils/api";
+
+const DATABASE_NAME = "offline-study-progress.db";
+
+type ProgressType = "lesson" | "review";
+
+type PendingProgressRow = {
+  id: number;
+  assignment_id: number;
+  subject_id: number | null;
+  progress_type: ProgressType;
+  meaning_incorrect_count: number;
+  reading_incorrect_count: number;
+  created_at: string | null;
+  available_at: string | null;
+  retry_count: number;
+  inserted_at: number;
+  updated_at: number;
+  last_error: string | null;
+};
+
+export type PendingProgressEntry = {
+  id: number;
+  assignmentId: number;
+  subjectId: number | null;
+  progressType: ProgressType;
+  meaningIncorrectCount: number;
+  readingIncorrectCount: number;
+  createdAt: string | null;
+  availableAt: string | null;
+  retryCount: number;
+  insertedAt: number;
+  updatedAt: number;
+  lastError: string | null;
+};
+
+export type QueueProgressPayload = {
+  assignmentId: number;
+  subjectId?: number | null;
+  progressType: ProgressType;
+  meaningIncorrectCount?: number;
+  readingIncorrectCount?: number;
+  createdAt?: string | null;
+  availableAt?: string | null;
+};
+
+export type ProgressSendFailureReason =
+  | "permission"
+  | "validation"
+  | "network"
+  | "api"
+  | "unknown";
+
+export type ProgressSendFailure = {
+  assignmentId: number;
+  progressType: ProgressType;
+  statusCode: number | null;
+  isPermissionError: boolean;
+  isValidationError: boolean;
+  reason: ProgressSendFailureReason;
+  message: string;
+};
+
+export type QueueProgressAttemptResult = {
+  response: any | null;
+  failure?: ProgressSendFailure;
+  queued: boolean;
+};
+
+export type PendingProgressSyncResult = {
+  processed: number;
+  sent: number;
+  droppedValidation: number;
+  remaining: number;
+  stoppedOnFailure: boolean;
+  failure?: ProgressSendFailure;
+};
+
+let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
+let syncLock: Promise<void> = Promise.resolve();
+
+function mapPendingRow(row: PendingProgressRow): PendingProgressEntry {
+  return {
+    id: row.id,
+    assignmentId: row.assignment_id,
+    subjectId: row.subject_id,
+    progressType: row.progress_type,
+    meaningIncorrectCount: row.meaning_incorrect_count,
+    readingIncorrectCount: row.reading_incorrect_count,
+    createdAt: row.created_at,
+    availableAt: row.available_at,
+    retryCount: row.retry_count,
+    insertedAt: row.inserted_at,
+    updatedAt: row.updated_at,
+    lastError: row.last_error,
+  };
+}
+
+function isLikelyNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("network request failed") ||
+    message.includes("failed to fetch") ||
+    message.includes("timed out") ||
+    message.includes("network")
+  );
+}
+
+function toFailure(error: unknown, row: PendingProgressEntry): ProgressSendFailure {
+  const statusCode = error instanceof ApiError ? error.statusCode : null;
+  const isPermissionError = statusCode === 401 || statusCode === 403;
+  const isValidationError = statusCode === 422;
+
+  let reason: ProgressSendFailureReason = "unknown";
+  if (isPermissionError) {
+    reason = "permission";
+  } else if (isValidationError) {
+    reason = "validation";
+  } else if (statusCode !== null) {
+    reason = "api";
+  } else if (isLikelyNetworkError(error)) {
+    reason = "network";
+  }
+
+  return {
+    assignmentId: row.assignmentId,
+    progressType: row.progressType,
+    statusCode,
+    isPermissionError,
+    isValidationError,
+    reason,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function withSyncLock<T>(fn: () => Promise<T>): Promise<T> {
+  const previousLock = syncLock;
+  let releaseLock!: () => void;
+  syncLock = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  await previousLock;
+  try {
+    return await fn();
+  } finally {
+    releaseLock();
+  }
+}
+
+async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (!dbPromise) {
+    dbPromise = (async () => {
+      const db = await SQLite.openDatabaseAsync(DATABASE_NAME);
+      await db.execAsync(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE IF NOT EXISTS pending_progress (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          assignment_id INTEGER NOT NULL,
+          subject_id INTEGER,
+          progress_type TEXT NOT NULL CHECK(progress_type IN ('lesson', 'review')),
+          meaning_incorrect_count INTEGER NOT NULL DEFAULT 0,
+          reading_incorrect_count INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT,
+          available_at TEXT,
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          inserted_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          last_error TEXT,
+          UNIQUE (assignment_id, progress_type)
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending_progress_inserted_at
+          ON pending_progress (inserted_at);
+        CREATE INDEX IF NOT EXISTS idx_pending_progress_type_assignment
+          ON pending_progress (progress_type, assignment_id);
+      `);
+      return db;
+    })();
+  }
+
+  return dbPromise;
+}
+
+async function getPendingRowByAssignmentAndType(
+  db: SQLite.SQLiteDatabase,
+  assignmentId: number,
+  progressType: ProgressType
+): Promise<PendingProgressEntry | null> {
+  const row = await db.getFirstAsync<PendingProgressRow>(
+    `SELECT
+      id,
+      assignment_id,
+      subject_id,
+      progress_type,
+      meaning_incorrect_count,
+      reading_incorrect_count,
+      created_at,
+      available_at,
+      retry_count,
+      inserted_at,
+      updated_at,
+      last_error
+     FROM pending_progress
+     WHERE assignment_id = ? AND progress_type = ?
+     LIMIT 1`,
+    assignmentId,
+    progressType
+  );
+
+  return row ? mapPendingRow(row) : null;
+}
+
+async function upsertPendingProgress(
+  db: SQLite.SQLiteDatabase,
+  payload: QueueProgressPayload
+): Promise<PendingProgressEntry> {
+  const now = Date.now();
+  const meaningIncorrectCount = Math.max(
+    0,
+    Math.trunc(payload.meaningIncorrectCount ?? 0)
+  );
+  const readingIncorrectCount = Math.max(
+    0,
+    Math.trunc(payload.readingIncorrectCount ?? 0)
+  );
+
+  await db.runAsync(
+    `INSERT INTO pending_progress (
+      assignment_id,
+      subject_id,
+      progress_type,
+      meaning_incorrect_count,
+      reading_incorrect_count,
+      created_at,
+      available_at,
+      retry_count,
+      inserted_at,
+      updated_at,
+      last_error
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, NULL)
+    ON CONFLICT(assignment_id, progress_type) DO UPDATE SET
+      subject_id = excluded.subject_id,
+      meaning_incorrect_count = excluded.meaning_incorrect_count,
+      reading_incorrect_count = excluded.reading_incorrect_count,
+      created_at = excluded.created_at,
+      available_at = excluded.available_at,
+      updated_at = excluded.updated_at,
+      last_error = NULL`,
+    payload.assignmentId,
+    payload.subjectId ?? null,
+    payload.progressType,
+    meaningIncorrectCount,
+    readingIncorrectCount,
+    payload.createdAt ?? null,
+    payload.availableAt ?? null,
+    now,
+    now
+  );
+
+  const row = await getPendingRowByAssignmentAndType(
+    db,
+    payload.assignmentId,
+    payload.progressType
+  );
+  if (!row) {
+    throw new Error(
+      `Failed to load queued progress row for assignment ${payload.assignmentId}`
+    );
+  }
+  return row;
+}
+
+async function deletePendingProgressById(
+  db: SQLite.SQLiteDatabase,
+  id: number
+): Promise<void> {
+  await db.runAsync("DELETE FROM pending_progress WHERE id = ?", id);
+}
+
+async function markPendingProgressFailure(
+  db: SQLite.SQLiteDatabase,
+  id: number,
+  failure: ProgressSendFailure
+): Promise<void> {
+  await db.runAsync(
+    `UPDATE pending_progress
+     SET retry_count = retry_count + 1,
+         updated_at = ?,
+         last_error = ?
+     WHERE id = ?`,
+    Date.now(),
+    failure.message,
+    id
+  );
+}
+
+async function sendPendingProgressRow(
+  row: PendingProgressEntry,
+  apiToken: string
+): Promise<QueueProgressAttemptResult> {
+  try {
+    if (row.progressType === "lesson") {
+      const response = await startLesson(
+        apiToken,
+        row.assignmentId,
+        row.createdAt ?? undefined
+      );
+      return {
+        response,
+        queued: false,
+      };
+    }
+
+    const response = await submitReview(
+      apiToken,
+      row.assignmentId,
+      row.meaningIncorrectCount,
+      row.readingIncorrectCount,
+      row.createdAt ?? undefined
+    );
+    return {
+      response,
+      queued: false,
+    };
+  } catch (error) {
+    const failure = toFailure(error, row);
+    return {
+      response: null,
+      failure,
+      queued: !failure.isValidationError,
+    };
+  }
+}
+
+async function getPendingRows(
+  db: SQLite.SQLiteDatabase,
+  limit?: number
+): Promise<PendingProgressEntry[]> {
+  const normalizedLimit =
+    typeof limit === "number" && Number.isFinite(limit) && limit > 0
+      ? Math.trunc(limit)
+      : null;
+
+  const query = `SELECT
+      id,
+      assignment_id,
+      subject_id,
+      progress_type,
+      meaning_incorrect_count,
+      reading_incorrect_count,
+      created_at,
+      available_at,
+      retry_count,
+      inserted_at,
+      updated_at,
+      last_error
+    FROM pending_progress
+    ORDER BY inserted_at ASC, id ASC${
+      normalizedLimit !== null ? " LIMIT ?" : ""
+    }`;
+
+  const rows =
+    normalizedLimit !== null
+      ? await db.getAllAsync<PendingProgressRow>(query, normalizedLimit)
+      : await db.getAllAsync<PendingProgressRow>(query);
+
+  return rows.map(mapPendingRow);
+}
+
+export async function getPendingProgressCounts(): Promise<{
+  lesson: number;
+  review: number;
+  total: number;
+}> {
+  const db = await getDatabase();
+  const row = await db.getFirstAsync<{
+    lesson_count: number;
+    review_count: number;
+    total_count: number;
+  }>(
+    `SELECT
+      SUM(CASE WHEN progress_type = 'lesson' THEN 1 ELSE 0 END) AS lesson_count,
+      SUM(CASE WHEN progress_type = 'review' THEN 1 ELSE 0 END) AS review_count,
+      COUNT(*) AS total_count
+    FROM pending_progress`
+  );
+
+  return {
+    lesson: row?.lesson_count ?? 0,
+    review: row?.review_count ?? 0,
+    total: row?.total_count ?? 0,
+  };
+}
+
+export async function getPendingProgressAssignmentIds(): Promise<{
+  lesson: Set<number>;
+  review: Set<number>;
+}> {
+  const db = await getDatabase();
+  const rows = await db.getAllAsync<{
+    assignment_id: number;
+    progress_type: ProgressType;
+  }>(`SELECT assignment_id, progress_type FROM pending_progress`);
+
+  const lesson = new Set<number>();
+  const review = new Set<number>();
+
+  for (const row of rows) {
+    if (row.progress_type === "lesson") {
+      lesson.add(row.assignment_id);
+    } else {
+      review.add(row.assignment_id);
+    }
+  }
+
+  return { lesson, review };
+}
+
+export async function queueProgressAndAttemptSend(
+  apiToken: string,
+  payload: QueueProgressPayload
+): Promise<QueueProgressAttemptResult> {
+  if (!apiToken) {
+    throw new Error("API token is required to queue progress");
+  }
+
+  return withSyncLock(async () => {
+    const db = await getDatabase();
+    const queuedRow = await upsertPendingProgress(db, payload);
+    const attempt = await sendPendingProgressRow(queuedRow, apiToken);
+
+    if (attempt.response) {
+      await deletePendingProgressById(db, queuedRow.id);
+      return attempt;
+    }
+
+    if (attempt.failure?.isValidationError) {
+      await deletePendingProgressById(db, queuedRow.id);
+      return {
+        ...attempt,
+        queued: false,
+      };
+    }
+
+    if (attempt.failure) {
+      await markPendingProgressFailure(db, queuedRow.id, attempt.failure);
+    }
+
+    return {
+      ...attempt,
+      queued: true,
+    };
+  });
+}
+
+export async function syncPendingProgress(
+  apiToken: string,
+  options: { limit?: number } = {}
+): Promise<PendingProgressSyncResult> {
+  if (!apiToken) {
+    return {
+      processed: 0,
+      sent: 0,
+      droppedValidation: 0,
+      remaining: 0,
+      stoppedOnFailure: false,
+    };
+  }
+
+  return withSyncLock(async () => {
+    const db = await getDatabase();
+    const rows = await getPendingRows(db, options.limit);
+
+    let processed = 0;
+    let sent = 0;
+    let droppedValidation = 0;
+    let stoppedOnFailure = false;
+    let lastFailure: ProgressSendFailure | undefined;
+
+    for (const row of rows) {
+      const attempt = await sendPendingProgressRow(row, apiToken);
+      processed += 1;
+
+      if (attempt.response) {
+        sent += 1;
+        await deletePendingProgressById(db, row.id);
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        continue;
+      }
+
+      if (attempt.failure?.isValidationError) {
+        droppedValidation += 1;
+        await deletePendingProgressById(db, row.id);
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        continue;
+      }
+
+      if (attempt.failure) {
+        await markPendingProgressFailure(db, row.id, attempt.failure);
+        lastFailure = attempt.failure;
+      }
+
+      stoppedOnFailure = true;
+      break;
+    }
+
+    const counts = await getPendingProgressCounts();
+    return {
+      processed,
+      sent,
+      droppedValidation,
+      remaining: counts.total,
+      stoppedOnFailure,
+      failure: lastFailure,
+    };
+  });
+}

--- a/src/services/studyProgressAssignmentCacheService.ts
+++ b/src/services/studyProgressAssignmentCacheService.ts
@@ -1,0 +1,218 @@
+import {
+  Assignment,
+  CollectionResponse,
+} from "../utils/api";
+import { getFromCache, saveToCache } from "../utils/cache";
+import {
+  getFromPermanentStorage,
+  PERMANENT_KEYS,
+  saveAssignmentsToPermanentStorage,
+} from "../utils/permanentStorage";
+
+const ASSIGNMENTS_CACHE_KEY = "assignments_all";
+const LESSON_FIRST_REVIEW_INTERVAL_HOURS = 4;
+
+const SRS_INTERVALS_HOURS: Record<number, number | null> = {
+  1: 4,
+  2: 8,
+  3: 23,
+  4: 47,
+  5: 167,
+  6: 335,
+  7: 719,
+  8: 2879,
+  9: null,
+};
+
+type AssignmentCacheMutation = {
+  assignmentId: number;
+  mutate: (assignment: Assignment, nowIso: string) => Assignment;
+};
+
+function addHours(dateIso: string, hours: number): string {
+  const baseMs = Date.parse(dateIso);
+  const normalizedBaseMs = Number.isFinite(baseMs) ? baseMs : Date.now();
+  return new Date(normalizedBaseMs + hours * 60 * 60 * 1000).toISOString();
+}
+
+function calculateOptimisticReviewEndingStage(
+  currentStage: number,
+  meaningIncorrect: number,
+  readingIncorrect: number
+): number {
+  const normalizedStage = Math.max(1, Math.min(9, Math.trunc(currentStage || 1)));
+  const incorrectAdjustmentCount =
+    (meaningIncorrect > 0 ? 1 : 0) + (readingIncorrect > 0 ? 1 : 0);
+
+  if (incorrectAdjustmentCount === 0) {
+    return Math.min(normalizedStage + 1, 9);
+  }
+
+  const penalty =
+    Math.floor(incorrectAdjustmentCount / 2) + Math.ceil(normalizedStage / 2);
+  return Math.max(normalizedStage - penalty, 1);
+}
+
+function getNextReviewAvailableAt(
+  srsStage: number,
+  completedAt: string
+): string | null {
+  const intervalHours = SRS_INTERVALS_HOURS[srsStage] ?? null;
+  if (intervalHours === null) {
+    return null;
+  }
+  return addHours(completedAt, intervalHours);
+}
+
+function updateAssignmentsArray(
+  assignments: Assignment[],
+  mutation: AssignmentCacheMutation,
+  nowIso: string
+): { assignments: Assignment[]; changed: boolean } {
+  let changed = false;
+  const updatedAssignments = assignments.map((assignment) => {
+    if (assignment.id !== mutation.assignmentId) {
+      return assignment;
+    }
+
+    changed = true;
+    return mutation.mutate(assignment, nowIso);
+  });
+
+  return { assignments: updatedAssignments, changed };
+}
+
+async function updateAssignmentCaches(
+  mutation: AssignmentCacheMutation
+): Promise<void> {
+  const nowIso = new Date().toISOString();
+  let latestAssignments: Assignment[] | null = null;
+
+  const cachedCollection = await getFromCache<CollectionResponse<Assignment>>(
+    ASSIGNMENTS_CACHE_KEY,
+    undefined,
+    { ignoreTTL: true }
+  );
+
+  if (cachedCollection?.data?.data) {
+    const updated = updateAssignmentsArray(
+      cachedCollection.data.data,
+      mutation,
+      nowIso
+    );
+
+    if (updated.changed) {
+      latestAssignments = updated.assignments;
+      await saveToCache(
+        ASSIGNMENTS_CACHE_KEY,
+        {
+          ...cachedCollection.data,
+          data: updated.assignments,
+        },
+        cachedCollection.data.data_updated_at
+      );
+    }
+  }
+
+  const permanentEntry = await getFromPermanentStorage<Assignment[]>(
+    PERMANENT_KEYS.ALL_ASSIGNMENTS,
+    { ignoreTTL: true }
+  );
+
+  if (permanentEntry?.data) {
+    const updated = updateAssignmentsArray(
+      permanentEntry.data,
+      mutation,
+      nowIso
+    );
+
+    if (updated.changed) {
+      latestAssignments = updated.assignments;
+      await saveAssignmentsToPermanentStorage(
+        updated.assignments,
+        permanentEntry.dataUpdatedAt
+      );
+    }
+  } else if (latestAssignments) {
+    await saveAssignmentsToPermanentStorage(latestAssignments, nowIso);
+  }
+}
+
+export async function markLessonStartedInAssignmentCaches({
+  assignmentId,
+  startedAt,
+}: {
+  assignmentId: number;
+  startedAt: string;
+}): Promise<void> {
+  await updateAssignmentCaches({
+    assignmentId,
+    mutate: (assignment, nowIso) => {
+      const effectiveStartedAt = assignment.data.started_at ?? startedAt;
+      return {
+        ...assignment,
+        data_updated_at: nowIso,
+        data: {
+          ...assignment.data,
+          started_at: effectiveStartedAt,
+          srs_stage: Math.max(assignment.data.srs_stage ?? 0, 1),
+          available_at: addHours(
+            effectiveStartedAt,
+            LESSON_FIRST_REVIEW_INTERVAL_HOURS
+          ),
+        },
+      };
+    },
+  });
+}
+
+export async function markReviewSubmittedInAssignmentCaches({
+  assignmentId,
+  meaningIncorrectCount,
+  readingIncorrectCount,
+  completedAt,
+  currentSrsStage,
+  endingSrsStage,
+  nextReviewAt,
+}: {
+  assignmentId: number;
+  meaningIncorrectCount: number;
+  readingIncorrectCount: number;
+  completedAt: string;
+  currentSrsStage?: number;
+  endingSrsStage?: number;
+  nextReviewAt?: string | null;
+}): Promise<void> {
+  await updateAssignmentCaches({
+    assignmentId,
+    mutate: (assignment, nowIso) => {
+      const endingStage =
+        endingSrsStage ??
+        calculateOptimisticReviewEndingStage(
+          currentSrsStage ?? assignment.data.srs_stage ?? 1,
+          meaningIncorrectCount,
+          readingIncorrectCount
+        );
+      const resolvedNextReviewAt =
+        nextReviewAt ?? getNextReviewAvailableAt(endingStage, completedAt);
+
+      return {
+        ...assignment,
+        data_updated_at: nowIso,
+        data: {
+          ...assignment.data,
+          srs_stage: endingStage,
+          available_at: resolvedNextReviewAt,
+          passed_at:
+            !assignment.data.passed_at && endingStage >= 5
+              ? completedAt
+              : assignment.data.passed_at,
+          burned_at:
+            !assignment.data.burned_at && endingStage >= 9
+              ? completedAt
+              : assignment.data.burned_at,
+        },
+      };
+    },
+  });
+}

--- a/src/utils/__tests__/apiOfflineFallback.test.ts
+++ b/src/utils/__tests__/apiOfflineFallback.test.ts
@@ -1,0 +1,193 @@
+const NOW_ISO = "2026-05-28T12:00:00.000Z";
+
+const makeAssignment = (id: number, overrides: Partial<any> = {}) => ({
+  id,
+  object: "assignment",
+  url: `https://api.wanikani.com/v2/assignments/${id}`,
+  data_updated_at: "2026-05-28T08:00:00.000Z",
+  data: {
+    created_at: "2026-05-28T08:00:00.000Z",
+    subject_id: 1000 + id,
+    subject_type: "kanji",
+    srs_stage: 0,
+    unlocked_at: "2026-05-27T08:00:00.000Z",
+    started_at: null,
+    passed_at: null,
+    burned_at: null,
+    available_at: null,
+    resurrected_at: null,
+    hidden: false,
+    ...overrides,
+  },
+});
+
+const makeAssignmentsCollection = (assignments: any[]) => ({
+  object: "collection",
+  url: "https://api.wanikani.com/v2/assignments",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: assignments.length,
+  data_updated_at: "2026-05-28T08:00:00.000Z",
+  data: assignments,
+});
+
+const mockResponse = (data: any) => {
+  const body = JSON.stringify(data);
+
+  return Promise.resolve({
+    status: 200,
+    ok: true,
+    headers: {
+      get: jest.fn(() => null),
+    },
+    json: jest.fn(() => Promise.resolve(data)),
+    text: jest.fn(() => Promise.resolve(body)),
+  });
+};
+
+describe("api offline assignment fallbacks", () => {
+  let dateNowSpy: jest.SpyInstance<number, []>;
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
+    dateNowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(new Date(NOW_ISO).getTime());
+    consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  const loadApi = ({
+    permanentAssignments = [],
+  }: {
+    permanentAssignments?: any[];
+  } = {}) => {
+    const getFromCacheMock = jest.fn(async () => null);
+    const saveAssignmentsToPermanentStorageMock = jest.fn(
+      async () => undefined
+    );
+
+    jest.doMock("../cache", () => ({
+      CACHE_TTL: 24 * 60 * 60 * 1000,
+      getCachedSubject: jest.fn(),
+      getDataUpdatedAt: jest.fn(async () => null),
+      getETag: jest.fn(async () => null),
+      getFromCache: getFromCacheMock,
+      getLastModified: jest.fn(async () => null),
+      getSubjectById: jest.fn(async () => null),
+      saveDataUpdatedAt: jest.fn(async () => undefined),
+      saveETag: jest.fn(async () => undefined),
+      saveLastModified: jest.fn(async () => undefined),
+      saveToCache: jest.fn(async () => undefined),
+    }));
+
+    jest.doMock("../permanentStorage", () => ({
+      PERMANENT_KEYS: {
+        ALL_ASSIGNMENTS: "assignments_all",
+        ALL_SUBJECTS: "subjects_all",
+        SUBJECTS_METADATA: "subjects_metadata",
+      },
+      getAssignmentsFromPermanentStorage: jest.fn(
+        async () => permanentAssignments
+      ),
+      getFromPermanentStorage: jest.fn(async () => null),
+      permanentStorage: {
+        contains: jest.fn(() => false),
+        getString: jest.fn(() => null),
+      },
+      removeFromPermanentStorage: jest.fn(async () => undefined),
+      saveAssignmentsToPermanentStorage:
+        saveAssignmentsToPermanentStorageMock,
+      saveSubjectsMetadata: jest.fn(async () => undefined),
+      saveToPermanentStorage: jest.fn(async () => undefined),
+    }));
+
+    jest.doMock("../apiDebugger", () => ({
+      apiDebugger: {
+        logCall: jest.fn(),
+        logNetworkCall: jest.fn(async () => undefined),
+      },
+    }));
+
+    jest.doMock("../performanceLogger", () => ({
+      startPerformanceTimer: jest.fn(() => ({
+        end: jest.fn(),
+      })),
+    }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const api = require("../api");
+
+    return {
+      api,
+      getFromCacheMock,
+      saveAssignmentsToPermanentStorageMock,
+    };
+  };
+
+  it("uses permanent assignments for available lessons when offline cache is missing", async () => {
+    const availableLesson = makeAssignment(1);
+    const startedLesson = makeAssignment(2, {
+      started_at: "2026-05-28T09:00:00.000Z",
+      srs_stage: 1,
+    });
+    const futureLesson = makeAssignment(3, {
+      unlocked_at: "2026-05-29T09:00:00.000Z",
+    });
+
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("offline"));
+
+    const { api, getFromCacheMock } = loadApi({
+      permanentAssignments: [availableLesson, startedLesson, futureLesson],
+    });
+
+    const result = await api.getAvailableLessons("test-token");
+
+    expect(getFromCacheMock).toHaveBeenCalled();
+    expect(result.data.map((assignment: any) => assignment.id)).toEqual([1]);
+    expect(result.total_count).toBe(1);
+    expect(result.pages.next_url).toBeNull();
+  });
+
+  it("reconciles an empty live lesson response against assignment data", async () => {
+    const availableLesson = makeAssignment(4);
+    const startedLesson = makeAssignment(5, {
+      started_at: "2026-05-28T09:00:00.000Z",
+      srs_stage: 1,
+    });
+
+    (global.fetch as jest.Mock)
+      .mockImplementationOnce(() => mockResponse(makeAssignmentsCollection([])))
+      .mockImplementationOnce(() =>
+        mockResponse(makeAssignmentsCollection([availableLesson, startedLesson]))
+      );
+
+    const { api, saveAssignmentsToPermanentStorageMock } = loadApi();
+
+    const result = await api.getAvailableLessons("test-token");
+
+    expect(result.data.map((assignment: any) => assignment.id)).toEqual([4]);
+    expect(result.total_count).toBe(1);
+    expect(saveAssignmentsToPermanentStorageMock).toHaveBeenCalledWith(
+      [availableLesson, startedLesson],
+      "2026-05-28T08:00:00.000Z"
+    );
+  });
+});

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -18,6 +18,10 @@ import {
     saveToCache
 } from "./cache";
 import { startPerformanceTimer } from "./performanceLogger";
+import {
+  getAssignmentsFromPermanentStorage,
+  saveAssignmentsToPermanentStorage,
+} from "./permanentStorage";
 import { startupDiagnostics } from "./startupDiagnostics";
 
 export const API_BASE_URL = "https://api.wanikani.com/v2";
@@ -664,6 +668,67 @@ export type ApiResponse<T> = {
   data: T;
 };
 
+function buildAssignmentsCollectionFromLocalData(
+  assignments: Assignment[],
+  dataUpdatedAt?: string
+): CollectionResponse<Assignment> {
+  const latestDataUpdatedAt =
+    dataUpdatedAt ??
+    assignments.reduce<string | null>((latest, assignment) => {
+      const assignmentDataUpdatedAt = assignment.data_updated_at;
+      if (!assignmentDataUpdatedAt) {
+        return latest;
+      }
+      if (!latest || Date.parse(assignmentDataUpdatedAt) > Date.parse(latest)) {
+        return assignmentDataUpdatedAt;
+      }
+      return latest;
+    }, null) ??
+    new Date().toISOString();
+
+  return {
+    object: "collection",
+    url: `${API_BASE_URL}/assignments`,
+    pages: {
+      per_page: 500,
+      next_url: null,
+      previous_url: null,
+    },
+    total_count: assignments.length,
+    data_updated_at: latestDataUpdatedAt,
+    data: assignments,
+  };
+}
+
+async function getPermanentAssignmentsCollection(): Promise<
+  CollectionResponse<Assignment> | null
+> {
+  const permanentAssignments = await getAssignmentsFromPermanentStorage({
+    ignoreTTL: true,
+  });
+
+  if (!permanentAssignments || permanentAssignments.length === 0) {
+    return null;
+  }
+
+  return buildAssignmentsCollectionFromLocalData(
+    permanentAssignments as Assignment[]
+  );
+}
+
+async function saveAssignmentsCollectionForOfflineUse(
+  assignments: CollectionResponse<Assignment>
+): Promise<void> {
+  try {
+    await saveAssignmentsToPermanentStorage(
+      assignments.data,
+      assignments.data_updated_at
+    );
+  } catch (error) {
+    console.warn("[API] Failed to persist assignments for offline use:", error);
+  }
+}
+
 // Note: WaniKani doesn't provide a direct email/password API
 // This function simulates what that would look like by opening the browser
 // and letting the user log in through WaniKani's website
@@ -1256,6 +1321,7 @@ export async function getAssignmentsOptimized(
             };
 
             await saveToCache(cacheKey, mergedData, allUpdated.data_updated_at);
+            await saveAssignmentsCollectionForOfflineUse(mergedData);
             await saveDataUpdatedAt('assignments', allUpdated.data_updated_at);
 
             timer.end({
@@ -1285,6 +1351,7 @@ export async function getAssignmentsOptimized(
 
       // Save to cache
       await saveToCache(cacheKey, allAssignments, allAssignments.data_updated_at);
+      await saveAssignmentsCollectionForOfflineUse(allAssignments);
       await saveDataUpdatedAt('assignments', allAssignments.data_updated_at);
 
       timer.end({ result: 'full_fetch', count: allAssignments.data.length });
@@ -1300,6 +1367,13 @@ export async function getAssignmentsOptimized(
         timer.end({ result: 'cache_fallback' });
         return cached.data;
       }
+
+      const permanentAssignments = await getPermanentAssignmentsCollection();
+      if (permanentAssignments) {
+        timer.end({ result: 'permanent_cache_fallback' });
+        return permanentAssignments;
+      }
+
       timer.end(
         { error: error instanceof Error ? error.message : String(error) },
         false
@@ -1685,8 +1759,9 @@ export async function getSubjects(
   if (params.slugs) params.slugs = [...params.slugs].sort();
   if (params.types) params.types = [...params.types].sort();
 
-  // Optimisation: Check memory cache for specific IDs first
-  if (params.ids && params.ids.length > 0 && Object.keys(params).length === 1 && !options?.skipCollectionCache) {
+  // Optimisation: Check the subject-by-id cache for specific IDs first. This is
+  // also the offline path for lesson sessions, even when collection caching is skipped.
+  if (params.ids && params.ids.length > 0 && Object.keys(params).length === 1) {
     const memoryResults = await Promise.all(params.ids.map(id => getSubjectById(id)));
     const allFound = memoryResults.every(s => !!s);
 
@@ -2974,6 +3049,77 @@ export async function startAssignment(
   return response.json();
 }
 
+function buildAvailableReviewsFromAssignments(
+  assignments: CollectionResponse<Assignment>
+): CollectionResponse<Assignment> {
+  const nowMs = Date.now();
+  const reviewAssignments = assignments.data.filter((assignment) => {
+    if (!isAssignmentInReviewQueueState(assignment.data)) {
+      return false;
+    }
+
+    const availableAtMs = Date.parse(assignment.data.available_at);
+    return Number.isFinite(availableAtMs) && availableAtMs <= nowMs;
+  });
+
+  return {
+    ...assignments,
+    data: reviewAssignments,
+    total_count: reviewAssignments.length,
+    pages: {
+      ...assignments.pages,
+      next_url: null,
+    },
+  };
+}
+
+function buildAvailableLessonsFromAssignments(
+  assignments: CollectionResponse<Assignment>
+): CollectionResponse<Assignment> {
+  const nowMs = Date.now();
+  const lessonAssignments = assignments.data.filter((assignment) => {
+    const assignmentData = assignment?.data;
+    if (!isAssignmentInLessonQueueState(assignmentData)) {
+      return false;
+    }
+
+    const unlockedAtMs = Date.parse(assignmentData.unlocked_at);
+    return Number.isFinite(unlockedAtMs) && unlockedAtMs <= nowMs;
+  });
+
+  return {
+    ...assignments,
+    data: lessonAssignments,
+    total_count: lessonAssignments.length,
+    pages: {
+      ...assignments.pages,
+      next_url: null,
+    },
+  };
+}
+
+async function getAvailableReviewsFromCachedAssignments(
+  apiToken: string
+): Promise<CollectionResponse<Assignment>> {
+  const cachedAssignments = await getAssignmentsOptimized(
+    apiToken,
+    {},
+    { forceFullRefresh: false }
+  );
+  return buildAvailableReviewsFromAssignments(cachedAssignments);
+}
+
+async function getAvailableLessonsFromCachedAssignments(
+  apiToken: string
+): Promise<CollectionResponse<Assignment>> {
+  const cachedAssignments = await getAssignmentsOptimized(
+    apiToken,
+    {},
+    { forceFullRefresh: false }
+  );
+  return buildAvailableLessonsFromAssignments(cachedAssignments);
+}
+
 /**
  * Get assignments that are available for formal reviews (will count towards SRS)
  */
@@ -2991,30 +3137,7 @@ export async function getAvailableReviews(
     return fetchAllPages(initialResponse, apiToken);
   } catch {
     // Offline/cache fallback: use locally cached assignments if possible.
-    const cachedAssignments = await getAssignmentsOptimized(
-      apiToken,
-      {},
-      { forceFullRefresh: false }
-    );
-    const nowMs = Date.now();
-    const filtered = cachedAssignments.data.filter((assignment) => {
-      if (!isAssignmentInReviewQueueState(assignment.data)) {
-        return false;
-      }
-
-      const availableAtMs = Date.parse(assignment.data.available_at);
-      return Number.isFinite(availableAtMs) && availableAtMs <= nowMs;
-    });
-
-    return {
-      ...cachedAssignments,
-      data: filtered,
-      total_count: filtered.length,
-      pages: {
-        ...cachedAssignments.pages,
-        next_url: null,
-      },
-    };
+    return getAvailableReviewsFromCachedAssignments(apiToken);
   }
 }
 
@@ -3032,34 +3155,32 @@ export async function getAvailableLessons(
     });
 
     // Handle pagination to get all pages
-    return fetchAllPages(initialResponse, apiToken);
+    const liveLessons = await fetchAllPages(initialResponse, apiToken);
+    if (liveLessons.data.length > 0) {
+      return liveLessons;
+    }
+
+    try {
+      const cachedLessons = await getAvailableLessonsFromCachedAssignments(
+        apiToken
+      );
+      if (cachedLessons.data.length > 0) {
+        console.warn(
+          "[Lessons] Live lesson endpoint returned zero lessons; using cached assignment-derived lessons."
+        );
+        return cachedLessons;
+      }
+    } catch (fallbackError) {
+      console.warn(
+        "[Lessons] Failed to reconcile empty live lesson response with cached assignments:",
+        fallbackError
+      );
+    }
+
+    return liveLessons;
   } catch {
     // Offline/cache fallback: use locally cached assignments if possible.
-    const cachedAssignments = await getAssignmentsOptimized(
-      apiToken,
-      {},
-      { forceFullRefresh: false }
-    );
-    const nowMs = Date.now();
-    const filtered = cachedAssignments.data.filter((assignment) => {
-      const assignmentData = assignment?.data;
-      if (!isAssignmentInLessonQueueState(assignmentData)) {
-        return false;
-      }
-
-      const unlockedAtMs = Date.parse(assignmentData.unlocked_at);
-      return Number.isFinite(unlockedAtMs) && unlockedAtMs <= nowMs;
-    });
-
-    return {
-      ...cachedAssignments,
-      data: filtered,
-      total_count: filtered.length,
-      pages: {
-        ...cachedAssignments.pages,
-        next_url: null,
-      },
-    };
+    return getAvailableLessonsFromCachedAssignments(apiToken);
   }
 }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2980,14 +2980,42 @@ export async function startAssignment(
 export async function getAvailableReviews(
   apiToken: string
 ): Promise<CollectionResponse<Assignment>> {
-  // Get assignments that are immediately available for review
-  const initialResponse = await getAssignments(apiToken, {
-    immediately_available_for_review: true,
-    hidden: false,
-  });
+  try {
+    // Get assignments that are immediately available for review
+    const initialResponse = await getAssignments(apiToken, {
+      immediately_available_for_review: true,
+      hidden: false,
+    });
 
-  // Handle pagination to get all pages
-  return fetchAllPages(initialResponse, apiToken);
+    // Handle pagination to get all pages
+    return fetchAllPages(initialResponse, apiToken);
+  } catch {
+    // Offline/cache fallback: use locally cached assignments if possible.
+    const cachedAssignments = await getAssignmentsOptimized(
+      apiToken,
+      {},
+      { forceFullRefresh: false }
+    );
+    const nowMs = Date.now();
+    const filtered = cachedAssignments.data.filter((assignment) => {
+      if (!isAssignmentInReviewQueueState(assignment.data)) {
+        return false;
+      }
+
+      const availableAtMs = Date.parse(assignment.data.available_at);
+      return Number.isFinite(availableAtMs) && availableAtMs <= nowMs;
+    });
+
+    return {
+      ...cachedAssignments,
+      data: filtered,
+      total_count: filtered.length,
+      pages: {
+        ...cachedAssignments.pages,
+        next_url: null,
+      },
+    };
+  }
 }
 
 /**
@@ -2996,14 +3024,43 @@ export async function getAvailableReviews(
 export async function getAvailableLessons(
   apiToken: string
 ): Promise<CollectionResponse<Assignment>> {
-  // Get assignments that are immediately available for lessons
-  const initialResponse = await getAssignments(apiToken, {
-    immediately_available_for_lessons: true,
-    burned: false,
-  });
+  try {
+    // Get assignments that are immediately available for lessons
+    const initialResponse = await getAssignments(apiToken, {
+      immediately_available_for_lessons: true,
+      burned: false,
+    });
 
-  // Handle pagination to get all pages
-  return fetchAllPages(initialResponse, apiToken);
+    // Handle pagination to get all pages
+    return fetchAllPages(initialResponse, apiToken);
+  } catch {
+    // Offline/cache fallback: use locally cached assignments if possible.
+    const cachedAssignments = await getAssignmentsOptimized(
+      apiToken,
+      {},
+      { forceFullRefresh: false }
+    );
+    const nowMs = Date.now();
+    const filtered = cachedAssignments.data.filter((assignment) => {
+      const assignmentData = assignment?.data;
+      if (!isAssignmentInLessonQueueState(assignmentData)) {
+        return false;
+      }
+
+      const unlockedAtMs = Date.parse(assignmentData.unlocked_at);
+      return Number.isFinite(unlockedAtMs) && unlockedAtMs <= nowMs;
+    });
+
+    return {
+      ...cachedAssignments,
+      data: filtered,
+      total_count: filtered.length,
+      pages: {
+        ...cachedAssignments.pages,
+        next_url: null,
+      },
+    };
+  }
 }
 
 /**
@@ -3210,8 +3267,20 @@ export async function getReviewCount(apiToken: string): Promise<number> {
     }
     return buildVisibleReviewDataFromAssignments(response.data).currentReviews;
   } catch (error) {
-    console.error('Error fetching review count:', error);
-    return 0; // Return 0 if there's an error to avoid breaking the app
+    try {
+      // Offline/cache fallback.
+      const cachedAssignments = await getAssignmentsOptimized(
+        apiToken,
+        {},
+        { forceFullRefresh: false }
+      );
+      return buildVisibleReviewDataFromAssignments(cachedAssignments.data)
+        .currentReviews;
+    } catch (fallbackError) {
+      console.error("Error fetching review count:", error);
+      console.error("Error fetching cached review count:", fallbackError);
+      return 0; // Return 0 if there's an error to avoid breaking the app
+    }
   }
 }
 
@@ -3231,6 +3300,42 @@ type AssignmentLike =
   | {
       data?: Partial<Assignment["data"]> | null;
     };
+
+/**
+ * Returns true when an assignment is in a lesson-ready state.
+ */
+export function isAssignmentInLessonQueueState(
+  assignmentData: AssignmentDataLike
+): assignmentData is Partial<Assignment["data"]> & {
+  unlocked_at: string;
+  subject_id: number;
+} {
+  if (!assignmentData) {
+    return false;
+  }
+
+  if (
+    !assignmentData.unlocked_at ||
+    assignmentData.started_at ||
+    assignmentData.hidden ||
+    typeof assignmentData.subject_id !== "number"
+  ) {
+    return false;
+  }
+
+  if (
+    typeof assignmentData.srs_stage === "number" &&
+    assignmentData.srs_stage !== 0
+  ) {
+    return false;
+  }
+
+  if (assignmentData.burned_at) {
+    return false;
+  }
+
+  return true;
+}
 
 /**
  * Returns true when an assignment is in a reviewable state.


### PR DESCRIPTION
## Summary
- Queue lesson and review submissions when the API is unavailable, then sync them on startup/foreground
- Update local assignment caches after offline lessons/reviews so lessons disappear and reviews appear after the SRS interval
- Make lesson loading fall back to persisted assignment data when the live lesson endpoint is empty/offline
- Update dashboard counts to account for pending offline progress


## Testing

Tested on testflight