### PR TITLE
[Fix] Keep Practice Mistakes active after constellation exit

### DIFF
--- a/app/(app)/constellation.tsx
+++ b/app/(app)/constellation.tsx
@@ -1,6 +1,6 @@
 import { useAuthStore } from "@/src/utils/store";
 import { Ionicons } from "@expo/vector-icons";
-import { router, useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams, useNavigation } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import React, { useEffect, useMemo, useRef } from "react";
 import {
@@ -125,7 +125,8 @@ interface NormalizedReadingEntry {
 type SubjectReading = NonNullable<Subject["data"]["readings"]>[number];
 
 export default function ConstellationScreen() {
-  const { id, rootId } = useLocalSearchParams();
+  const { id, rootId, constellationDepth } = useLocalSearchParams();
+  const navigation = useNavigation();
   const { dashboardData } = useDashboardData();
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
@@ -147,8 +148,19 @@ export default function ConstellationScreen() {
     return combined;
   }, [dashboardData.subjects, fetchedSubjects]);
 
+  const idParam = Array.isArray(id) ? id[0] : id;
+  const rootIdParam = Array.isArray(rootId) ? rootId[0] : rootId;
+  const depthParam = Array.isArray(constellationDepth)
+    ? constellationDepth[0]
+    : constellationDepth;
+  const parsedDepth = Number(depthParam);
+  const currentConstellationDepth =
+    Number.isFinite(parsedDepth) && parsedDepth > 0
+      ? Math.floor(parsedDepth)
+      : 1;
+
   // Find the subject from combined list
-  const subjectId = Number(id);
+  const subjectId = Number(idParam);
   const subject = useMemo(
     () => allSubjects.find((s) => s.id === subjectId),
     [allSubjects, subjectId]
@@ -689,7 +701,11 @@ export default function ConstellationScreen() {
     // Push new screen instead of replace to keep history stack
     router.push({
       pathname: "/constellation",
-      params: { id: nodeId.toString(), rootId: rootId || id },
+      params: {
+        id: nodeId.toString(),
+        rootId: rootIdParam || idParam || subjectId.toString(),
+        constellationDepth: (currentConstellationDepth + 1).toString(),
+      },
     });
   };
 
@@ -701,19 +717,38 @@ export default function ConstellationScreen() {
     router.back();
   };
 
-  const handleExitRabbitHole = () => {
-    if (rootId) {
-      // Pop all the way back to the root subject
-      // We can use router.navigate nicely here if we know the path, but router.dismiss or router.popToTop doesn't behave exactly as "pop to specific ID in stack" in expo-router usually.
-      // The easiest way is to push back to the subject detail screen, but that adds to history.
-      // Better: simply navigate to the subject detail screen.
-      router.dismissAll();
-      // Since we are in a stack, dismissing all might take us to tabs.
-      // Let's use router.navigate to the subject details.
-      router.navigate(`/subject/${rootId}`);
-    } else {
-      router.back();
+  const getConstellationDismissCount = () => {
+    const state = navigation.getState();
+    const routes = state?.routes ?? [];
+    const currentIndex =
+      typeof state?.index === "number" ? state.index : routes.length - 1;
+    let consecutiveConstellationScreens = 0;
+
+    for (let routeIndex = currentIndex; routeIndex >= 0; routeIndex -= 1) {
+      const routeName = routes[routeIndex]?.name ?? "";
+      if (
+        routeName !== "constellation" &&
+        !routeName.endsWith("/constellation")
+      ) {
+        break;
+      }
+      consecutiveConstellationScreens += 1;
     }
+
+    if (consecutiveConstellationScreens > 0) {
+      return consecutiveConstellationScreens;
+    }
+
+    return routes.length > 0 ? 1 : currentConstellationDepth;
+  };
+
+  const handleExitRabbitHole = () => {
+    if (!rootIdParam && !depthParam) {
+      router.back();
+      return;
+    }
+
+    router.dismiss(getConstellationDismissCount());
   };
 
   if (!subject && loadingMissing) {

--- a/app/(app)/subject/[id].tsx
+++ b/app/(app)/subject/[id].tsx
@@ -1067,7 +1067,11 @@ export default function SubjectDetailsScreen() {
             onOpenConstellation={() =>
               router.push({
                 pathname: "/constellation",
-                params: { id: subjectData.id, rootId: subjectData.id },
+                params: {
+                  id: subjectData.id,
+                  rootId: subjectData.id,
+                  constellationDepth: "1",
+                },
               })
             }
           />
@@ -1170,7 +1174,11 @@ export default function SubjectDetailsScreen() {
             onOpenConstellation={() =>
               router.push({
                 pathname: "/constellation",
-                params: { id: subjectData.id, rootId: subjectData.id },
+                params: {
+                  id: subjectData.id,
+                  rootId: subjectData.id,
+                  constellationDepth: "1",
+                },
               })
             }
           />
@@ -1274,7 +1282,11 @@ export default function SubjectDetailsScreen() {
             onOpenConstellation={() =>
               router.push({
                 pathname: "/constellation",
-                params: { id: subjectData.id, rootId: subjectData.id },
+                params: {
+                  id: subjectData.id,
+                  rootId: subjectData.id,
+                  constellationDepth: "1",
+                },
               })
             }
           />

--- a/src/components/LessonDetailScreen.tsx
+++ b/src/components/LessonDetailScreen.tsx
@@ -137,6 +137,11 @@ const ANDROID_RIGHT_ARROW_KEY_CODE = 22;
 const WEB_LEFT_ARROW_KEY_CODE = 37;
 const WEB_RIGHT_ARROW_KEY_CODE = 39;
 
+const deferStateUpdate = (update: () => void) => {
+  const timeout = setTimeout(update, 0);
+  return () => clearTimeout(timeout);
+};
+
 interface SimilarVocabularyItem {
   id: number;
   characters: string;
@@ -768,17 +773,20 @@ const SubjectContent = ({
     };
   }, []);
 
-  // These effects intentionally reset async section state when the active
-  // subject or enabled detail sections change.
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     let isMounted = true;
 
     if (!shouldLoadSimilarVocabulary) {
-      setCachedVocabularySubjects([]);
-      setLoadingSimilarVocabulary(false);
+      const cancelReset = deferStateUpdate(() => {
+        if (!isMounted) {
+          return;
+        }
+        setCachedVocabularySubjects([]);
+        setLoadingSimilarVocabulary(false);
+      });
       return () => {
         isMounted = false;
+        cancelReset();
       };
     }
 
@@ -848,7 +856,7 @@ const SubjectContent = ({
 
   useEffect(() => {
     if (Platform.OS !== "android" || noteModalVisible) return;
-    setAndroidKeyboardHeight(0);
+    return deferStateUpdate(() => setAndroidKeyboardHeight(0));
   }, [noteModalVisible]);
 
   const handleNoteModalOverlayLayout = (event: LayoutChangeEvent) => {
@@ -886,17 +894,19 @@ const SubjectContent = ({
   // Reset scroll position when subject changes
   useEffect(() => {
     scrollViewRef.current?.scrollTo({ x: 0, y: 0, animated: false });
-    setRevealedTranslations(new Set());
-    setSentencePlaybackSpeeds({});
-    setExpandedSentenceSpeedId(null);
-    setSelectedUsagePatternIndex(0);
-    setShowAllSimilarByMeaning(false);
-    setShowAllSimilarByReading(false);
+    return deferStateUpdate(() => {
+      setRevealedTranslations(new Set());
+      setSentencePlaybackSpeeds({});
+      setExpandedSentenceSpeedId(null);
+      setSelectedUsagePatternIndex(0);
+      setShowAllSimilarByMeaning(false);
+      setShowAllSimilarByReading(false);
+    });
   }, [subject.id]);
 
   useEffect(() => {
     if (!showContextSentenceSpeedControl) {
-      setExpandedSentenceSpeedId(null);
+      return deferStateUpdate(() => setExpandedSentenceSpeedId(null));
     }
   }, [showContextSentenceSpeedControl]);
 
@@ -907,8 +917,7 @@ const SubjectContent = ({
       visuallySimilarKanjiSource !== "niai" ||
       !shouldLoadKanjiVisualSimilar
     ) {
-      setNiaiSimilarKanji([]);
-      return;
+      return deferStateUpdate(() => setNiaiSimilarKanji([]));
     }
 
     const kanjiChar = subject.data?.characters;
@@ -936,13 +945,22 @@ const SubjectContent = ({
       !singleKanjiVocabularyCharacter ||
       !shouldLoadSingleKanjiVocabularySimilarKanji
     ) {
-      setSingleKanjiVocabularySimilarKanji([]);
+      const cancelReset = deferStateUpdate(() => {
+        if (isMounted) {
+          setSingleKanjiVocabularySimilarKanji([]);
+        }
+      });
       return () => {
         isMounted = false;
+        cancelReset();
       };
     }
 
-    setSingleKanjiVocabularySimilarKanji([]);
+    const cancelInitialReset = deferStateUpdate(() => {
+      if (isMounted) {
+        setSingleKanjiVocabularySimilarKanji([]);
+      }
+    });
 
     const loadSimilarKanji = async () => {
       try {
@@ -1032,6 +1050,7 @@ const SubjectContent = ({
 
     return () => {
       isMounted = false;
+      cancelInitialReset();
     };
   }, [
     singleKanjiVocabularyCharacter,
@@ -1097,8 +1116,7 @@ const SubjectContent = ({
   // Fetch study materials for user synonyms and notes
   useEffect(() => {
     if (!apiToken || !subject.id || !shouldLoadStudyMaterials) {
-      applyStudyMaterialState(null);
-      return;
+      return deferStateUpdate(() => applyStudyMaterialState(null));
     }
 
     getStudyMaterials(apiToken, { subject_ids: [subject.id] })
@@ -1215,16 +1233,19 @@ const SubjectContent = ({
 
   useEffect(() => {
     if (!shouldLoadMediaContextSentences) {
-      setLoadingMediaSentences(false);
-      setMediaSentences([]);
-      setNextDataOffset(0);
-      setVisibleMediaCount(10);
-      return;
+      return deferStateUpdate(() => {
+        setLoadingMediaSentences(false);
+        setMediaSentences([]);
+        setNextDataOffset(0);
+        setVisibleMediaCount(10);
+      });
     }
 
-    setNextDataOffset(0);
-    setVisibleMediaCount(10);
-    fetchMediaSentences(0);
+    return deferStateUpdate(() => {
+      setNextDataOffset(0);
+      setVisibleMediaCount(10);
+      fetchMediaSentences(0);
+    });
   }, [fetchMediaSentences, shouldLoadMediaContextSentences]);
 
   const loadMoreMediaSentences = () => {
@@ -1251,8 +1272,7 @@ const SubjectContent = ({
       !shouldLoadRadicalMnemonicIllustration ||
       !documentUrl
     ) {
-      setRadicalMnemonicImageUrl(null);
-      return;
+      return deferStateUpdate(() => setRadicalMnemonicImageUrl(null));
     }
 
     getMnemonicImageUrlFromDocument(documentUrl)
@@ -1283,13 +1303,19 @@ const SubjectContent = ({
       !shouldLoadRadicalMnemonicIllustration ||
       !radicalMnemonicImageUrl
     ) {
-      setRadicalMnemonicSvgXml(null);
-      setRadicalMnemonicImageKind("unknown");
-      return;
+      return deferStateUpdate(() => {
+        setRadicalMnemonicSvgXml(null);
+        setRadicalMnemonicImageKind("unknown");
+      });
     }
 
-    setRadicalMnemonicSvgXml(null);
-    setRadicalMnemonicImageKind("unknown");
+    const cancelInitialReset = deferStateUpdate(() => {
+      if (cancelled) {
+        return;
+      }
+      setRadicalMnemonicSvgXml(null);
+      setRadicalMnemonicImageKind("unknown");
+    });
 
     getMnemonicImageAsset(radicalMnemonicImageUrl)
       .then((asset) => {
@@ -1311,6 +1337,7 @@ const SubjectContent = ({
 
     return () => {
       cancelled = true;
+      cancelInitialReset();
     };
   }, [
     subject.id,
@@ -1319,8 +1346,6 @@ const SubjectContent = ({
     shouldLoadRadicalMnemonicIllustration,
     radicalMnemonicImageUrl,
   ]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
   // Format mnemonic text with HTML highlighting (similar to KanjiDetails.tsx)
   const formatMnemonic = (mnemonic: string) => {
     if (!mnemonic) return null;

--- a/src/components/LessonDetailScreen.tsx
+++ b/src/components/LessonDetailScreen.tsx
@@ -430,9 +430,10 @@ const SubjectContent = ({
   const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
   const [androidNoteModalLayoutHeight, setAndroidNoteModalLayoutHeight] =
     useState(0);
+  const [androidBaselineModalHeight, setAndroidBaselineModalHeight] =
+    useState(0);
   const { apiToken } = useAuthStore();
   const mountedRef = useRef(true);
-  const androidBaselineModalHeightRef = useRef(0);
 
   // Visually similar kanji state (for Niai source)
   const [niaiSimilarKanji, setNiaiSimilarKanji] = useState<any[]>([]);
@@ -464,8 +465,7 @@ const SubjectContent = ({
   }, [
     subject.id,
     subject.object,
-    subject.data?.characters,
-    subject.data?.readings,
+    subject.data,
   ]);
   const usagePatterns = useMemo(() => {
     if (subject.object !== "vocabulary" && subject.object !== "kana_vocabulary") {
@@ -477,7 +477,7 @@ const SubjectContent = ({
       typeof subject.data?.characters === "string" ? subject.data.characters : "";
 
     return getWaniKaniVocabularyPatterns(level, characters);
-  }, [subject.object, subject.data?.level, subject.data?.characters]);
+  }, [subject.object, subject.data]);
   const selectedUsagePattern =
     usagePatterns[selectedUsagePatternIndex] ?? usagePatterns[0] ?? null;
   const isVocabularySubject =
@@ -527,7 +527,7 @@ const SubjectContent = ({
     }
 
     return set;
-  }, [isVocabularySubject, subject.data?.readings]);
+  }, [isVocabularySubject, subject.data.readings]);
 
   const subjectMeaningSet = useMemo(() => {
     if (!isVocabularySubject || !Array.isArray(subject.data?.meanings)) {
@@ -543,7 +543,7 @@ const SubjectContent = ({
     }
 
     return set;
-  }, [isVocabularySubject, subject.data?.meanings]);
+  }, [isVocabularySubject, subject.data]);
 
   const similarVocabularyByReading = useMemo<SimilarVocabularyItem[]>(() => {
     if (!showSimilarVocabulary || !isVocabularySubject || subjectReadingSet.size === 0) {
@@ -685,7 +685,7 @@ const SubjectContent = ({
       mpegAudios,
       Array.isArray(subject.data?.readings) ? subject.data.readings : null
     );
-  }, [subject.data?.pronunciation_audios, subject.data?.readings]);
+  }, [subject.data.pronunciation_audios, subject.data.readings]);
 
   const orderedVocabularyComponentSubjectIds = useMemo(() => {
     if (subject.object !== "vocabulary") {
@@ -732,8 +732,8 @@ const SubjectContent = ({
       .map((entry: OrderedComponentSubjectEntry) => entry.id);
   }, [
     subject.object,
-    subject.data?.component_subject_ids,
-    subject.data?.characters,
+    subject.data.component_subject_ids,
+    subject.data.characters,
     relatedSubjects,
   ]);
   const singleKanjiVocabularyCharacter = useMemo(
@@ -742,7 +742,7 @@ const SubjectContent = ({
         subject.object,
         subject.data?.characters
       ),
-    [subject.object, subject.data?.characters]
+    [subject.object, subject.data.characters]
   );
 
   const renderPitchAccent = (withBottomMargin = false) => {
@@ -768,6 +768,9 @@ const SubjectContent = ({
     };
   }, []);
 
+  // These effects intentionally reset async section state when the active
+  // subject or enabled detail sections change.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     let isMounted = true;
 
@@ -844,15 +847,6 @@ const SubjectContent = ({
   }, []);
 
   useEffect(() => {
-    if (Platform.OS !== "android") return;
-    if (androidKeyboardHeight > 0 || androidNoteModalLayoutHeight <= 0) return;
-    androidBaselineModalHeightRef.current = Math.max(
-      androidBaselineModalHeightRef.current,
-      androidNoteModalLayoutHeight,
-    );
-  }, [androidKeyboardHeight, androidNoteModalLayoutHeight]);
-
-  useEffect(() => {
     if (Platform.OS !== "android" || noteModalVisible) return;
     setAndroidKeyboardHeight(0);
   }, [noteModalVisible]);
@@ -860,6 +854,11 @@ const SubjectContent = ({
   const handleNoteModalOverlayLayout = (event: LayoutChangeEvent) => {
     if (Platform.OS !== "android") return;
     const nextHeight = Math.round(event.nativeEvent.layout.height);
+    if (androidKeyboardHeight <= 0) {
+      setAndroidBaselineModalHeight((currentHeight) =>
+        Math.max(currentHeight, nextHeight),
+      );
+    }
     setAndroidNoteModalLayoutHeight((currentHeight) =>
       currentHeight === nextHeight ? currentHeight : nextHeight,
     );
@@ -1211,7 +1210,7 @@ const SubjectContent = ({
     shouldLoadMediaContextSentences,
     myAnimeListUsername,
     immersionKitAnimes,
-    userData?.level,
+    userData,
   ]);
 
   useEffect(() => {
@@ -1320,6 +1319,7 @@ const SubjectContent = ({
     shouldLoadRadicalMnemonicIllustration,
     radicalMnemonicImageUrl,
   ]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Format mnemonic text with HTML highlighting (similar to KanjiDetails.tsx)
   const formatMnemonic = (mnemonic: string) => {
@@ -4311,10 +4311,10 @@ const SubjectContent = ({
   const androidAppliedKeyboardResize =
     Platform.OS === "android" &&
     androidKeyboardHeight > 0 &&
-    androidBaselineModalHeightRef.current > 0
+    androidBaselineModalHeight > 0
       ? Math.max(
           0,
-          androidBaselineModalHeightRef.current - androidNoteModalLayoutHeight,
+          androidBaselineModalHeight - androidNoteModalLayoutHeight,
         )
       : 0;
   const androidKeyboardFallbackLift =
@@ -4439,7 +4439,6 @@ export default function LessonDetailScreen({
   const insets = useSafeAreaInsets();
   const subjectColors = useSubjectColors();
   const {
-    showStrokeOrder,
     singlePageLessonView,
     autoplayLessonReadingAudio,
     vocabularyAudioVoice,
@@ -4747,7 +4746,7 @@ export default function LessonDetailScreen({
         onBatchItemPress?.(newIndex);
       }
     },
-    [onBatchItemPress]
+    [onBatchItemPress, setIndex]
   );
 
   const isLastSubjectAndLastTab = useCallback(() => {
@@ -4856,13 +4855,13 @@ export default function LessonDetailScreen({
         draggedTowardPreviousRef.current = false;
       }
     },
-    [isLastSubjectAndLastTab, onNext]
+    [isLastSubjectAndLastTab, onNext, setIndex]
   );
 
   const handleConstellationPress = useCallback((subjectId: number) => {
     router.push({
       pathname: "/constellation",
-      params: { id: subjectId, rootId: subjectId },
+      params: { id: subjectId, rootId: subjectId, constellationDepth: "1" },
     });
   }, []);
 
@@ -6064,10 +6063,18 @@ const createStyles = (theme: any, subjectColors: SubjectColors) =>
       opacity: 0.18,
     },
     translationBlurOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      position: "absolute",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
     },
     translationRevealHint: {
-      ...StyleSheet.absoluteFillObject,
+      position: "absolute",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
       alignItems: "center",
       justifyContent: "center",
       flexDirection: "row",

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.71",
+    date: "2026-05-31",
+    changes: [
+      {
+        type: "fix",
+        title: "Practice Mistakes Navigation",
+        description:
+          "Constellation exit no longer ends Practice Mistakes review.",
+      },
+    ],
+  },
+  {
     version: "1.2.70",
     date: "2026-05-29",
     changes: [


### PR DESCRIPTION
## Summary
- Fix constellation exit navigation so it only closes constellation screens.
- Preserve the Practice Mistakes review stack when returning from subject details.
- Add the May 31 patch note.