### PR TITLE
[Feature] Add per-song lyrics timing offset

### DIFF
--- a/app/(app)/song-lyrics.tsx
+++ b/app/(app)/song-lyrics.tsx
@@ -371,6 +371,10 @@ export default function SongLyricsScreen() {
     useState<string | null>(null);
   const [hasLoadedLyricsTimingOffset, setHasLoadedLyricsTimingOffset] =
     useState(false);
+  const [isLyricsTimingAdjustmentEnabled, setIsLyricsTimingAdjustmentEnabled] =
+    useState(false);
+  const [isLyricsTimingControlVisible, setIsLyricsTimingControlVisible] =
+    useState(false);
 
   const vocabularyMatchesById = useMemo(
     () => new Map(vocabularyMatches.map((match) => [match.id, match])),
@@ -412,6 +416,14 @@ export default function SongLyricsScreen() {
     () => formatLyricsTimingOffset(lyricsTimingOffsetMs),
     [lyricsTimingOffsetMs]
   );
+  const activeLyricsTimingOffsetMs = isLyricsTimingAdjustmentEnabled
+    ? lyricsTimingOffsetMs
+    : 0;
+  const canAdjustLyricsTiming = timedLyrics.length > 0 && isTimedMode;
+  const shouldShowLyricsTimingControl =
+    canAdjustLyricsTiming &&
+    isLyricsTimingAdjustmentEnabled &&
+    isLyricsTimingControlVisible;
   const lyricsTimingOffsetMsRef = useRef(0);
   const staticLyricLines = useMemo(() => {
     if (!lyrics) {
@@ -945,6 +957,8 @@ export default function SongLyricsScreen() {
     let didCancel = false;
 
     setHasLoadedLyricsTimingOffset(false);
+    setIsLyricsTimingAdjustmentEnabled(false);
+    setIsLyricsTimingControlVisible(false);
     lyricsTimingOffsetMsRef.current = 0;
     setLyricsTimingOffsetMs(0);
 
@@ -969,12 +983,16 @@ export default function SongLyricsScreen() {
         const nextOffsetMs = clampLyricsTimingOffsetMs(parsedOffsetMs);
         lyricsTimingOffsetMsRef.current = nextOffsetMs;
         setLyricsTimingOffsetMs(nextOffsetMs);
+        setIsLyricsTimingAdjustmentEnabled(nextOffsetMs !== 0);
+        setIsLyricsTimingControlVisible(false);
         setHasLoadedLyricsTimingOffset(true);
       } catch (cacheError) {
         console.error("Error loading lyric timing offset:", cacheError);
         if (!didCancel) {
           lyricsTimingOffsetMsRef.current = 0;
           setLyricsTimingOffsetMs(0);
+          setIsLyricsTimingAdjustmentEnabled(false);
+          setIsLyricsTimingControlVisible(false);
           setHasLoadedLyricsTimingOffset(true);
         }
       }
@@ -996,7 +1014,9 @@ export default function SongLyricsScreen() {
       return;
     }
 
-    const normalizedOffsetMs = clampLyricsTimingOffsetMs(lyricsTimingOffsetMs);
+    const normalizedOffsetMs = isLyricsTimingAdjustmentEnabled
+      ? clampLyricsTimingOffsetMs(lyricsTimingOffsetMs)
+      : 0;
     const saveTimeout = setTimeout(() => {
       if (normalizedOffsetMs === 0) {
         AsyncStorage.removeItem(lyricsTimingOffsetCacheKey).catch((cacheError) =>
@@ -1019,6 +1039,7 @@ export default function SongLyricsScreen() {
   }, [
     lyricsTimingOffsetCacheKey,
     lyricsTimingOffsetMs,
+    isLyricsTimingAdjustmentEnabled,
     hasLoadedLyricsTimingOffset,
   ]);
 
@@ -1509,10 +1530,25 @@ export default function SongLyricsScreen() {
     setSongsLyricsLineTranslationsEnabled,
   ]);
 
+  const openLyricsTimingAdjustment = useCallback(() => {
+    setIsLyricsTimingAdjustmentEnabled(true);
+    setIsLyricsTimingControlVisible(true);
+    setIsAutoscrollEnabled(true);
+  }, []);
+
+  const closeLyricsTimingAdjustment = useCallback(() => {
+    setIsLyricsTimingControlVisible(false);
+    if (lyricsTimingOffsetMs === 0) {
+      setIsLyricsTimingAdjustmentEnabled(false);
+    }
+  }, [lyricsTimingOffsetMs]);
+
   const handleLyricsTimingOffsetChange = useCallback(
     (offsetSeconds: number) => {
       const nextOffsetMs = clampLyricsTimingOffsetMs(offsetSeconds * 1000);
       lyricsTimingOffsetMsRef.current = nextOffsetMs;
+      setIsLyricsTimingAdjustmentEnabled(true);
+      setIsLyricsTimingControlVisible(true);
       setLyricsTimingOffsetMs(nextOffsetMs);
       setIsAutoscrollEnabled(true);
     },
@@ -1525,6 +1561,8 @@ export default function SongLyricsScreen() {
         lyricsTimingOffsetMs + deltaMs
       );
       lyricsTimingOffsetMsRef.current = nextOffsetMs;
+      setIsLyricsTimingAdjustmentEnabled(true);
+      setIsLyricsTimingControlVisible(true);
       setLyricsTimingOffsetMs(nextOffsetMs);
       setIsAutoscrollEnabled(true);
     },
@@ -1533,6 +1571,8 @@ export default function SongLyricsScreen() {
 
   const resetLyricsTimingOffset = useCallback(() => {
     lyricsTimingOffsetMsRef.current = 0;
+    setIsLyricsTimingAdjustmentEnabled(false);
+    setIsLyricsTimingControlVisible(false);
     setLyricsTimingOffsetMs(0);
     setIsAutoscrollEnabled(true);
   }, [setLyricsTimingOffsetMs]);
@@ -1667,7 +1707,8 @@ export default function SongLyricsScreen() {
     )
       return;
 
-    const adjustedCurrentTimeMs = currentTime * 1000 - lyricsTimingOffsetMs;
+    const adjustedCurrentTimeMs =
+      currentTime * 1000 - activeLyricsTimingOffsetMs;
     const currentLineIndex = timedLyrics.findIndex((line, index) => {
       const nextLine = timedLyrics[index + 1];
       return (
@@ -1693,7 +1734,7 @@ export default function SongLyricsScreen() {
     }
   }, [
     currentTime,
-    lyricsTimingOffsetMs,
+    activeLyricsTimingOffsetMs,
     isTimedMode,
     isPlaying,
     timedLyrics,
@@ -2012,7 +2053,8 @@ export default function SongLyricsScreen() {
 
   // Helper function to render timed lyrics
   const renderTimedLyrics = (): ReactElement => {
-    const adjustedCurrentTimeMs = currentTime * 1000 - lyricsTimingOffsetMs;
+    const adjustedCurrentTimeMs =
+      currentTime * 1000 - activeLyricsTimingOffsetMs;
 
     return (
       <>
@@ -2028,7 +2070,7 @@ export default function SongLyricsScreen() {
             timedLineTranslationsForDisplay[index] ?? null;
           const seekTimeSeconds = Math.max(
             0,
-            (line.startTimeMs + lyricsTimingOffsetMs) / 1000
+            (line.startTimeMs + activeLyricsTimingOffsetMs) / 1000
           );
 
           return (
@@ -2383,34 +2425,87 @@ export default function SongLyricsScreen() {
                 Lyrics
               </Text>
               {timedLyrics.length > 0 && (
-                <View ref={syncToggleRef} style={styles.syncToggleRow}>
-                  <Ionicons
-                    name="sync"
-                    size={18}
-                    color={theme.textSecondary}
-                    style={{ marginRight: 8 }}
-                  />
-                  <Text
-                    style={[styles.syncToggleLabel, { color: theme.textSecondary }]}
-                  >
-                    Sync
-                  </Text>
-                  <Switch
-                    value={isTimedMode}
-                    onValueChange={(value) => {
-                      setIsTimedMode(value);
-                      if (value) {
-                        setIsAutoscrollEnabled(true);
-                      }
-                    }}
-                    trackColor={{ false: "#767577", true: theme.primary }}
-                    thumbColor="#f4f3f4"
-                  />
+                <View style={styles.lyricsTitleActions}>
+                  {isTimedMode && (
+                    <TouchableOpacity
+                      style={[
+                        styles.lyricsTimingToggleButton,
+                        {
+                          borderColor: theme.border,
+                          backgroundColor:
+                            isLyricsTimingAdjustmentEnabled
+                              ? withAlpha(
+                                  theme.primary,
+                                  theme.isDark ? 0.28 : 0.12
+                                )
+                              : "transparent",
+                        },
+                      ]}
+                      onPress={openLyricsTimingAdjustment}
+                      activeOpacity={0.7}
+                    >
+                      <Ionicons
+                        name="time-outline"
+                        size={14}
+                        color={
+                          isLyricsTimingAdjustmentEnabled
+                            ? theme.primary
+                            : theme.textSecondary
+                        }
+                      />
+                      <Text
+                        style={[
+                          styles.lyricsTimingToggleButtonText,
+                          {
+                            color:
+                              isLyricsTimingAdjustmentEnabled
+                                ? theme.primary
+                                : theme.textSecondary,
+                          },
+                        ]}
+                        numberOfLines={1}
+                      >
+                        {isLyricsTimingAdjustmentEnabled &&
+                        lyricsTimingOffsetMs !== 0
+                          ? lyricsTimingOffsetDisplay
+                          : "Delay"}
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                  <View ref={syncToggleRef} style={styles.syncToggleRow}>
+                    <Ionicons
+                      name="sync"
+                      size={18}
+                      color={theme.textSecondary}
+                      style={{ marginRight: 8 }}
+                    />
+                    <Text
+                      style={[
+                        styles.syncToggleLabel,
+                        { color: theme.textSecondary },
+                      ]}
+                    >
+                      Sync
+                    </Text>
+                    <Switch
+                      value={isTimedMode}
+                      onValueChange={(value) => {
+                        setIsTimedMode(value);
+                        if (value) {
+                          setIsAutoscrollEnabled(true);
+                        } else {
+                          setIsLyricsTimingControlVisible(false);
+                        }
+                      }}
+                      trackColor={{ false: "#767577", true: theme.primary }}
+                      thumbColor="#f4f3f4"
+                    />
+                  </View>
                 </View>
               )}
             </View>
 
-            {timedLyrics.length > 0 && isTimedMode && (
+            {shouldShowLyricsTimingControl ? (
               <View
                 style={[
                   styles.lyricsTimingControl,
@@ -2435,14 +2530,27 @@ export default function SongLyricsScreen() {
                       Lyrics timing
                     </Text>
                   </View>
-                  <Text
-                    style={[
-                      styles.lyricsTimingValue,
-                      { color: theme.textSecondary },
-                    ]}
-                  >
-                    {lyricsTimingOffsetDisplay}
-                  </Text>
+                  <View style={styles.lyricsTimingHeaderActions}>
+                    <Text
+                      style={[
+                        styles.lyricsTimingValue,
+                        { color: theme.textSecondary },
+                      ]}
+                    >
+                      {lyricsTimingOffsetDisplay}
+                    </Text>
+                    <TouchableOpacity
+                      style={styles.lyricsTimingCloseButton}
+                      onPress={closeLyricsTimingAdjustment}
+                      activeOpacity={0.7}
+                    >
+                      <Ionicons
+                        name="close"
+                        size={18}
+                        color={theme.textSecondary}
+                      />
+                    </TouchableOpacity>
+                  </View>
                 </View>
                 <Slider
                   style={styles.lyricsTimingSlider}
@@ -2541,7 +2649,7 @@ export default function SongLyricsScreen() {
                   </TouchableOpacity>
                 </View>
               </View>
-            )}
+            ) : null}
 
             {/* Show info message when timed lyrics unavailable and we're in static mode */}
             {timedLyricsStatus === "unavailable" &&
@@ -3407,6 +3515,13 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: "bold",
   },
+  lyricsTitleActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 8,
+    flexShrink: 1,
+  },
   syncToggleRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -3414,6 +3529,22 @@ const styles = StyleSheet.create({
   syncToggleLabel: {
     fontSize: 14,
     marginRight: 8,
+  },
+  lyricsTimingToggleButton: {
+    minHeight: 32,
+    maxWidth: 126,
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 9,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+  },
+  lyricsTimingToggleButtonText: {
+    fontSize: 12,
+    fontWeight: "700",
+    flexShrink: 1,
   },
   lyricsTimingControl: {
     borderTopWidth: 1,
@@ -3428,6 +3559,18 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     gap: 12,
+  },
+  lyricsTimingHeaderActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  lyricsTimingCloseButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
   },
   lyricsTimingTitleGroup: {
     flexDirection: "row",

--- a/app/(app)/song-lyrics.tsx
+++ b/app/(app)/song-lyrics.tsx
@@ -86,6 +86,8 @@ const GRAMMAR_TOOLTIP_ID_MIN = -9000000;
 const TOKEN_UNDERLINE_SEPARATOR = "\u200A";
 const LRC_TIMESTAMP_REGEX = /\[(?:\d{1,2}:)?\d{1,2}(?:\.\d{1,3})?\]/g;
 const LEADING_COMMA_PATTERN = /^\s*,\s*/;
+const JAPANESE_TEXT_PATTERN =
+  /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\u3005\u3006\u303b\uff66-\uff9f]/;
 const LYRICS_TIMING_OFFSET_MIN_MS = -60000;
 const LYRICS_TIMING_OFFSET_MAX_MS = 60000;
 const LYRICS_TIMING_OFFSET_STEP_MS = 500;
@@ -119,13 +121,17 @@ function normalizeLyricLineForTranslation(line: string): string {
   return line.replace(LRC_TIMESTAMP_REGEX, "").trim();
 }
 
+function containsJapaneseText(line: string): boolean {
+  return JAPANESE_TEXT_PATTERN.test(line);
+}
+
 function buildDisplayTranslationsForLines(
   lyricLines: string[],
   translationsByNormalizedLine: Record<string, string>
 ): (string | null)[] {
   const resolvedLines = lyricLines.map((line) => {
     const normalizedLine = normalizeLyricLineForTranslation(line);
-    if (!normalizedLine) {
+    if (!normalizedLine || !containsJapaneseText(normalizedLine)) {
       return null;
     }
 
@@ -458,7 +464,10 @@ export default function SongLyricsScreen() {
     () =>
       visibleLinesForTranslation
         .map((line) => normalizeLyricLineForTranslation(line))
-        .filter((line): line is string => line.length > 0),
+        .filter(
+          (line): line is string =>
+            line.length > 0 && containsJapaneseText(line)
+        ),
     [visibleLinesForTranslation]
   );
   const timedLineTranslationsForDisplay = useMemo(() => {
@@ -1078,7 +1087,11 @@ export default function SongLyricsScreen() {
         const normalizedTranslations = Object.entries(
           parsedCache as Record<string, unknown>
         ).reduce<Record<string, string>>((accumulator, [key, value]) => {
-          if (typeof key !== "string" || key.length === 0) {
+          if (typeof key !== "string") {
+            return accumulator;
+          }
+          const normalizedKey = normalizeLyricLineForTranslation(key);
+          if (!normalizedKey || !containsJapaneseText(normalizedKey)) {
             return accumulator;
           }
           if (typeof value !== "string") {
@@ -1090,7 +1103,7 @@ export default function SongLyricsScreen() {
             return accumulator;
           }
 
-          accumulator[key] = trimmedValue;
+          accumulator[normalizedKey] = trimmedValue;
           return accumulator;
         }, {});
 

--- a/app/(app)/song-lyrics.tsx
+++ b/app/(app)/song-lyrics.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import Slider from "@react-native-community/slider";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   memo,
@@ -85,6 +86,34 @@ const GRAMMAR_TOOLTIP_ID_MIN = -9000000;
 const TOKEN_UNDERLINE_SEPARATOR = "\u200A";
 const LRC_TIMESTAMP_REGEX = /\[(?:\d{1,2}:)?\d{1,2}(?:\.\d{1,3})?\]/g;
 const LEADING_COMMA_PATTERN = /^\s*,\s*/;
+const LYRICS_TIMING_OFFSET_MIN_MS = -60000;
+const LYRICS_TIMING_OFFSET_MAX_MS = 60000;
+const LYRICS_TIMING_OFFSET_STEP_MS = 500;
+
+function clampLyricsTimingOffsetMs(offsetMs: number): number {
+  if (!Number.isFinite(offsetMs)) {
+    return 0;
+  }
+
+  const roundedOffsetMs =
+    Math.round(offsetMs / LYRICS_TIMING_OFFSET_STEP_MS) *
+    LYRICS_TIMING_OFFSET_STEP_MS;
+  return Math.min(
+    LYRICS_TIMING_OFFSET_MAX_MS,
+    Math.max(LYRICS_TIMING_OFFSET_MIN_MS, roundedOffsetMs)
+  );
+}
+
+function formatLyricsTimingOffset(offsetMs: number): string {
+  if (offsetMs === 0) {
+    return "In sync";
+  }
+
+  const seconds = Math.abs(offsetMs) / 1000;
+  return offsetMs > 0
+    ? `Delay +${seconds.toFixed(1)}s`
+    : `Advance ${seconds.toFixed(1)}s`;
+}
 
 function normalizeLyricLineForTranslation(line: string): string {
   return line.replace(LRC_TIMESTAMP_REGEX, "").trim();
@@ -269,6 +298,8 @@ export default function SongLyricsScreen() {
     setSongInfo,
     setIsPlaying,
     setTimedLyrics: setGlobalTimedLyrics,
+    lyricsTimingOffsetMs,
+    setLyricsTimingOffsetMs,
   } = useMusicPlayer();
 
   const [lyrics, setLyrics] = useState<string>("");
@@ -338,6 +369,8 @@ export default function SongLyricsScreen() {
     useState(false);
   const [lyricsTranslationStatusMessage, setLyricsTranslationStatusMessage] =
     useState<string | null>(null);
+  const [hasLoadedLyricsTimingOffset, setHasLoadedLyricsTimingOffset] =
+    useState(false);
 
   const vocabularyMatchesById = useMemo(
     () => new Map(vocabularyMatches.map((match) => [match.id, match])),
@@ -371,6 +404,15 @@ export default function SongLyricsScreen() {
   const lineTranslationsCacheKey = songLyricsCacheBaseKey
     ? `${songLyricsCacheBaseKey}_translations`
     : null;
+  const lyricsTimingOffsetCacheKey = songLyricsCacheBaseKey
+    ? `${songLyricsCacheBaseKey}_lyrics_timing_offset_ms`
+    : null;
+  const lyricsTimingOffsetSeconds = lyricsTimingOffsetMs / 1000;
+  const lyricsTimingOffsetDisplay = useMemo(
+    () => formatLyricsTimingOffset(lyricsTimingOffsetMs),
+    [lyricsTimingOffsetMs]
+  );
+  const lyricsTimingOffsetMsRef = useRef(0);
   const staticLyricLines = useMemo(() => {
     if (!lyrics) {
       return [];
@@ -787,6 +829,7 @@ export default function SongLyricsScreen() {
           songId: effectiveAppleSongId,
           songUrl: musicSource === "apple" ? songUrl : undefined,
           musicSource: "apple",
+          lyricsTimingOffsetMs: lyricsTimingOffsetMsRef.current,
         });
         if (timedLinesForPlayer.length > 0) {
           setGlobalTimedLyrics(timedLinesForPlayer);
@@ -838,6 +881,7 @@ export default function SongLyricsScreen() {
           songId,
           songUrl,
           musicSource: "spotify",
+          lyricsTimingOffsetMs: lyricsTimingOffsetMsRef.current,
         });
         if (timedLinesForPlayer.length > 0) {
           setGlobalTimedLyrics(timedLinesForPlayer);
@@ -896,6 +940,87 @@ export default function SongLyricsScreen() {
   useEffect(() => {
     setLyricsTranslationStatusMessage(null);
   }, [songTitle, artist]);
+
+  useEffect(() => {
+    let didCancel = false;
+
+    setHasLoadedLyricsTimingOffset(false);
+    lyricsTimingOffsetMsRef.current = 0;
+    setLyricsTimingOffsetMs(0);
+
+    const loadLyricsTimingOffset = async () => {
+      if (!lyricsTimingOffsetCacheKey) {
+        if (!didCancel) {
+          setHasLoadedLyricsTimingOffset(true);
+        }
+        return;
+      }
+
+      try {
+        const cachedOffsetMs = await AsyncStorage.getItem(
+          lyricsTimingOffsetCacheKey
+        );
+        if (didCancel) {
+          return;
+        }
+
+        const parsedOffsetMs =
+          cachedOffsetMs === null ? 0 : Number.parseFloat(cachedOffsetMs);
+        const nextOffsetMs = clampLyricsTimingOffsetMs(parsedOffsetMs);
+        lyricsTimingOffsetMsRef.current = nextOffsetMs;
+        setLyricsTimingOffsetMs(nextOffsetMs);
+        setHasLoadedLyricsTimingOffset(true);
+      } catch (cacheError) {
+        console.error("Error loading lyric timing offset:", cacheError);
+        if (!didCancel) {
+          lyricsTimingOffsetMsRef.current = 0;
+          setLyricsTimingOffsetMs(0);
+          setHasLoadedLyricsTimingOffset(true);
+        }
+      }
+    };
+
+    void loadLyricsTimingOffset();
+
+    return () => {
+      didCancel = true;
+    };
+  }, [lyricsTimingOffsetCacheKey, setLyricsTimingOffsetMs]);
+
+  useEffect(() => {
+    lyricsTimingOffsetMsRef.current = lyricsTimingOffsetMs;
+  }, [lyricsTimingOffsetMs]);
+
+  useEffect(() => {
+    if (!lyricsTimingOffsetCacheKey || !hasLoadedLyricsTimingOffset) {
+      return;
+    }
+
+    const normalizedOffsetMs = clampLyricsTimingOffsetMs(lyricsTimingOffsetMs);
+    const saveTimeout = setTimeout(() => {
+      if (normalizedOffsetMs === 0) {
+        AsyncStorage.removeItem(lyricsTimingOffsetCacheKey).catch((cacheError) =>
+          console.error("Error clearing lyric timing offset:", cacheError)
+        );
+        return;
+      }
+
+      AsyncStorage.setItem(
+        lyricsTimingOffsetCacheKey,
+        String(normalizedOffsetMs)
+      ).catch((cacheError) =>
+        console.error("Error saving lyric timing offset:", cacheError)
+      );
+    }, 250);
+
+    return () => {
+      clearTimeout(saveTimeout);
+    };
+  }, [
+    lyricsTimingOffsetCacheKey,
+    lyricsTimingOffsetMs,
+    hasLoadedLyricsTimingOffset,
+  ]);
 
   useEffect(() => {
     let didCancel = false;
@@ -1384,6 +1509,34 @@ export default function SongLyricsScreen() {
     setSongsLyricsLineTranslationsEnabled,
   ]);
 
+  const handleLyricsTimingOffsetChange = useCallback(
+    (offsetSeconds: number) => {
+      const nextOffsetMs = clampLyricsTimingOffsetMs(offsetSeconds * 1000);
+      lyricsTimingOffsetMsRef.current = nextOffsetMs;
+      setLyricsTimingOffsetMs(nextOffsetMs);
+      setIsAutoscrollEnabled(true);
+    },
+    [setLyricsTimingOffsetMs]
+  );
+
+  const adjustLyricsTimingOffset = useCallback(
+    (deltaMs: number) => {
+      const nextOffsetMs = clampLyricsTimingOffsetMs(
+        lyricsTimingOffsetMs + deltaMs
+      );
+      lyricsTimingOffsetMsRef.current = nextOffsetMs;
+      setLyricsTimingOffsetMs(nextOffsetMs);
+      setIsAutoscrollEnabled(true);
+    },
+    [lyricsTimingOffsetMs, setLyricsTimingOffsetMs]
+  );
+
+  const resetLyricsTimingOffset = useCallback(() => {
+    lyricsTimingOffsetMsRef.current = 0;
+    setLyricsTimingOffsetMs(0);
+    setIsAutoscrollEnabled(true);
+  }, [setLyricsTimingOffsetMs]);
+
   const searchVideos = useCallback(async (query: string) => {
     if (!query.trim()) return;
 
@@ -1410,6 +1563,7 @@ export default function SongLyricsScreen() {
         songId,
         songUrl,
         musicSource: "spotify",
+        lyricsTimingOffsetMs: lyricsTimingOffsetMsRef.current,
       });
       setShowOverrideModal(false);
 
@@ -1513,12 +1667,12 @@ export default function SongLyricsScreen() {
     )
       return;
 
-    const currentTimeMs = currentTime * 1000;
+    const adjustedCurrentTimeMs = currentTime * 1000 - lyricsTimingOffsetMs;
     const currentLineIndex = timedLyrics.findIndex((line, index) => {
       const nextLine = timedLyrics[index + 1];
       return (
-        currentTimeMs >= line.startTimeMs &&
-        (!nextLine || currentTimeMs < nextLine.startTimeMs)
+        adjustedCurrentTimeMs >= line.startTimeMs &&
+        (!nextLine || adjustedCurrentTimeMs < nextLine.startTimeMs)
       );
     });
 
@@ -1539,6 +1693,7 @@ export default function SongLyricsScreen() {
     }
   }, [
     currentTime,
+    lyricsTimingOffsetMs,
     isTimedMode,
     isPlaying,
     timedLyrics,
@@ -1857,18 +2012,24 @@ export default function SongLyricsScreen() {
 
   // Helper function to render timed lyrics
   const renderTimedLyrics = (): ReactElement => {
-    const currentTimeMs = currentTime * 1000;
+    const adjustedCurrentTimeMs = currentTime * 1000 - lyricsTimingOffsetMs;
 
     return (
       <>
         {timedLyrics.map((line, index) => {
           const isCurrentLine =
-            currentTimeMs >= line.startTimeMs &&
+            adjustedCurrentTimeMs >= line.startTimeMs &&
             (!timedLyrics[index + 1] ||
-              currentTimeMs < timedLyrics[index + 1].startTimeMs);
+              adjustedCurrentTimeMs < timedLyrics[index + 1].startTimeMs);
 
-          const isPastLine = currentTimeMs > line.startTimeMs && !isCurrentLine;
-          const translatedLineText = timedLineTranslationsForDisplay[index] ?? null;
+          const isPastLine =
+            adjustedCurrentTimeMs > line.startTimeMs && !isCurrentLine;
+          const translatedLineText =
+            timedLineTranslationsForDisplay[index] ?? null;
+          const seekTimeSeconds = Math.max(
+            0,
+            (line.startTimeMs + lyricsTimingOffsetMs) / 1000
+          );
 
           return (
             <TouchableOpacity
@@ -1877,7 +2038,9 @@ export default function SongLyricsScreen() {
                 if (ref) lineRefs.current[index] = ref;
               }}
               style={styles.timedLyricLine}
-              onPress={fullAnalysisEnabled ? undefined : () => seekToTime(line.startTimeMs / 1000)}
+              onPress={
+                fullAnalysisEnabled ? undefined : () => seekToTime(seekTimeSeconds)
+              }
               disabled={fullAnalysisEnabled}
               activeOpacity={fullAnalysisEnabled ? 1 : 0.7}
             >
@@ -2246,6 +2409,139 @@ export default function SongLyricsScreen() {
                 </View>
               )}
             </View>
+
+            {timedLyrics.length > 0 && isTimedMode && (
+              <View
+                style={[
+                  styles.lyricsTimingControl,
+                  {
+                    borderColor: theme.border,
+                  },
+                ]}
+              >
+                <View style={styles.lyricsTimingHeader}>
+                  <View style={styles.lyricsTimingTitleGroup}>
+                    <Ionicons
+                      name="time-outline"
+                      size={16}
+                      color={theme.textSecondary}
+                    />
+                    <Text
+                      style={[
+                        styles.lyricsTimingTitle,
+                        { color: theme.textColor },
+                      ]}
+                    >
+                      Lyrics timing
+                    </Text>
+                  </View>
+                  <Text
+                    style={[
+                      styles.lyricsTimingValue,
+                      { color: theme.textSecondary },
+                    ]}
+                  >
+                    {lyricsTimingOffsetDisplay}
+                  </Text>
+                </View>
+                <Slider
+                  style={styles.lyricsTimingSlider}
+                  minimumValue={LYRICS_TIMING_OFFSET_MIN_MS / 1000}
+                  maximumValue={LYRICS_TIMING_OFFSET_MAX_MS / 1000}
+                  step={LYRICS_TIMING_OFFSET_STEP_MS / 1000}
+                  value={lyricsTimingOffsetSeconds}
+                  onValueChange={handleLyricsTimingOffsetChange}
+                  minimumTrackTintColor={theme.primary}
+                  maximumTrackTintColor={theme.border}
+                  thumbTintColor={theme.primary}
+                />
+                <View style={styles.lyricsTimingActions}>
+                  <TouchableOpacity
+                    style={[
+                      styles.lyricsTimingButton,
+                      { borderColor: theme.border },
+                      lyricsTimingOffsetMs <= LYRICS_TIMING_OFFSET_MIN_MS &&
+                        styles.lyricsTimingButtonDisabled,
+                    ]}
+                    onPress={() =>
+                      adjustLyricsTimingOffset(-LYRICS_TIMING_OFFSET_STEP_MS)
+                    }
+                    disabled={
+                      lyricsTimingOffsetMs <= LYRICS_TIMING_OFFSET_MIN_MS
+                    }
+                    activeOpacity={0.7}
+                  >
+                    <Ionicons
+                      name="play-back-outline"
+                      size={15}
+                      color={theme.textColor}
+                    />
+                    <Text
+                      style={[
+                        styles.lyricsTimingButtonText,
+                        { color: theme.textColor },
+                      ]}
+                    >
+                      -0.5s
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[
+                      styles.lyricsTimingButton,
+                      { borderColor: theme.border },
+                      lyricsTimingOffsetMs === 0 &&
+                        styles.lyricsTimingButtonDisabled,
+                    ]}
+                    onPress={resetLyricsTimingOffset}
+                    disabled={lyricsTimingOffsetMs === 0}
+                    activeOpacity={0.7}
+                  >
+                    <Ionicons
+                      name="refresh-outline"
+                      size={15}
+                      color={theme.textColor}
+                    />
+                    <Text
+                      style={[
+                        styles.lyricsTimingButtonText,
+                        { color: theme.textColor },
+                      ]}
+                    >
+                      Reset
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[
+                      styles.lyricsTimingButton,
+                      { borderColor: theme.border },
+                      lyricsTimingOffsetMs >= LYRICS_TIMING_OFFSET_MAX_MS &&
+                        styles.lyricsTimingButtonDisabled,
+                    ]}
+                    onPress={() =>
+                      adjustLyricsTimingOffset(LYRICS_TIMING_OFFSET_STEP_MS)
+                    }
+                    disabled={
+                      lyricsTimingOffsetMs >= LYRICS_TIMING_OFFSET_MAX_MS
+                    }
+                    activeOpacity={0.7}
+                  >
+                    <Text
+                      style={[
+                        styles.lyricsTimingButtonText,
+                        { color: theme.textColor },
+                      ]}
+                    >
+                      +0.5s
+                    </Text>
+                    <Ionicons
+                      name="play-forward-outline"
+                      size={15}
+                      color={theme.textColor}
+                    />
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
 
             {/* Show info message when timed lyrics unavailable and we're in static mode */}
             {timedLyricsStatus === "unavailable" &&
@@ -3118,6 +3414,60 @@ const styles = StyleSheet.create({
   syncToggleLabel: {
     fontSize: 14,
     marginRight: 8,
+  },
+  lyricsTimingControl: {
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    paddingHorizontal: 12,
+    paddingTop: 12,
+    paddingBottom: 12,
+    marginBottom: 16,
+  },
+  lyricsTimingHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  lyricsTimingTitleGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexShrink: 1,
+  },
+  lyricsTimingTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  lyricsTimingValue: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  lyricsTimingSlider: {
+    height: 36,
+    marginTop: 4,
+  },
+  lyricsTimingActions: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  lyricsTimingButton: {
+    flex: 1,
+    minHeight: 34,
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    paddingHorizontal: 8,
+  },
+  lyricsTimingButtonDisabled: {
+    opacity: 0.42,
+  },
+  lyricsTimingButtonText: {
+    fontSize: 12,
+    fontWeight: "700",
   },
   infoMessage: {
     flexDirection: "column",

--- a/src/components/GlobalMiniPlayer.tsx
+++ b/src/components/GlobalMiniPlayer.tsx
@@ -18,6 +18,7 @@ export default function GlobalMiniPlayer() {
     songId,
     songUrl,
     timedLyrics,
+    lyricsTimingOffsetMs,
     isPlaying,
     currentTime,
     duration,
@@ -278,6 +279,7 @@ export default function GlobalMiniPlayer() {
       currentTime={currentTime}
       duration={duration}
       timedLyrics={timedLyrics}
+      lyricsTimingOffsetMs={lyricsTimingOffsetMs}
       onPlayPause={togglePlayPause}
       onSkipBackward={skipBackward}
       onSkipForward={skipForward}

--- a/src/components/LessonDetailScreen.tsx
+++ b/src/components/LessonDetailScreen.tsx
@@ -2073,27 +2073,28 @@ const SubjectContent = ({
                     },
                   ]}
                 >
-                  <View style={styles.japaneseSentenceContainer}>
+                  <View style={styles.sentenceRow}>
                     <Text
                       selectable
                       style={[
                         styles.japaneseSentence,
-                        styles.japaneseSentenceWithButton,
+                        styles.usagePatternJapaneseSentence,
                       ]}
                     >
                       {example.ja}
                     </Text>
                     <TouchableOpacity
                       style={[
-                        styles.speakButtonFixed,
-                        isSpeaking && styles.speakingButtonFixed,
+                        styles.sentencePlayButton,
+                        isSpeaking && styles.sentencePlayButtonActive,
                       ]}
                       onPress={() => speakJapanese(example.ja, sentenceId)}
+                      activeOpacity={0.85}
                     >
                       <Ionicons
-                        name={isSpeaking ? "stop-circle" : "volume-high"}
-                        size={20}
-                        color={isSpeaking ? "white" : subjectColors.vocabulary}
+                        name={isSpeaking ? "stop" : "play"}
+                        size={16}
+                        color={isSpeaking ? "#fff" : subjectColors.vocabulary}
                       />
                     </TouchableOpacity>
                   </View>
@@ -6087,6 +6088,23 @@ const createStyles = (theme: any, subjectColors: SubjectColors) =>
     },
     patternExampleItem: {
       marginBottom: 10,
+    },
+    sentenceRow: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    usagePatternJapaneseSentence: {
+      flex: 1,
+    },
+    sentencePlayButton: {
+      padding: 8,
+      borderRadius: 16,
+      backgroundColor: withAlpha(subjectColors.vocabulary, 0.1),
+      marginLeft: 8,
+    },
+    sentencePlayButtonActive: {
+      backgroundColor: subjectColors.vocabulary,
+      borderRadius: 16,
     },
     sentenceItem: {
       backgroundColor: theme.isDark ? "#2a2a2a" : "#f9f9f9",

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -103,6 +103,7 @@ interface MiniPlayerProps {
   onNavigateToLyrics?: () => void;
   showLyricsButton?: boolean;
   timedLyrics?: TimedLyricsLine[];
+  lyricsTimingOffsetMs?: number;
 }
 
 export default function MiniPlayer({
@@ -126,6 +127,7 @@ export default function MiniPlayer({
   onNavigateToLyrics,
   showLyricsButton = false,
   timedLyrics = [],
+  lyricsTimingOffsetMs = 0,
 }: MiniPlayerProps) {
   const fadeAnim = useSharedValue(0);
   const translateY = useSharedValue(100);
@@ -398,18 +400,21 @@ export default function MiniPlayer({
       return;
     }
 
+    const adjustedCurrentTime = currentTime - lyricsTimingOffsetMs / 1000;
     const index = timedLyrics.findIndex((line, idx) => {
       const nextLine = timedLyrics[idx + 1];
       const lineTime = line.startTimeMs / 1000;
       const nextLineTime = nextLine ? nextLine.startTimeMs / 1000 : Infinity;
-      return currentTime >= lineTime && currentTime < nextLineTime;
+      return (
+        adjustedCurrentTime >= lineTime && adjustedCurrentTime < nextLineTime
+      );
     });
 
     // Only update if changed to avoid unnecessary re-renders
     if (index !== currentIndex) {
       setCurrentIndex(index);
     }
-  }, [currentTime, timedLyrics, currentIndex]);
+  }, [currentTime, lyricsTimingOffsetMs, timedLyrics, currentIndex]);
 
   // Scroll to active line
   useEffect(() => {
@@ -1086,7 +1091,10 @@ export default function MiniPlayer({
               ? undefined
               : () => {
                   if (playerRef?.current) {
-                    const seekTime = item.startTimeMs / 1000;
+                    const seekTime = Math.max(
+                      0,
+                      item.startTimeMs / 1000 + lyricsTimingOffsetMs / 1000
+                    );
                     handleSeekComplete(seekTime);
                   }
                 }
@@ -1137,6 +1145,7 @@ export default function MiniPlayer({
       fullAnalysisEnabled,
       wkStudyModeEnabled,
       timedLineOffsets,
+      lyricsTimingOffsetMs,
       handleSeekComplete,
       highlightTimedLyricLine,
     ]

--- a/src/contexts/MusicPlayerContext.tsx
+++ b/src/contexts/MusicPlayerContext.tsx
@@ -33,6 +33,7 @@ interface MusicPlayerContextType {
 
   // Lyrics
   timedLyrics: TimedLyricsLine[];
+  lyricsTimingOffsetMs: number;
 
   // Player state
   isPlaying: boolean;
@@ -52,6 +53,7 @@ interface MusicPlayerContextType {
     songId?: string;
     songUrl?: string;
     musicSource?: MusicSource;
+    lyricsTimingOffsetMs?: number;
   }) => void;
   setIsPlaying: (playing: boolean) => void;
   setCurrentTime: (time: number) => void;
@@ -63,6 +65,7 @@ interface MusicPlayerContextType {
   onStateChange: (state: string) => void;
   clearPlayer: () => void;
   setTimedLyrics: (lyrics: TimedLyricsLine[]) => void;
+  setLyricsTimingOffsetMs: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const MusicPlayerContext = createContext<MusicPlayerContextType | undefined>(
@@ -102,6 +105,7 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
 
   // Lyrics
   const [timedLyrics, setTimedLyrics] = useState<TimedLyricsLine[]>([]);
+  const [lyricsTimingOffsetMs, setLyricsTimingOffsetMs] = useState(0);
 
   // Player state
   const [isPlayingState, setIsPlayingState] = useState(false);
@@ -112,6 +116,7 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
   // Player refs
   const playerRef = useRef<any>(null);
   const appleListenersRef = useRef<EmitterSubscription[]>([]);
+  const lyricsTimingSongKeyRef = useRef<string | null>(null);
 
   const clearAppleListeners = useCallback(() => {
     for (const listener of appleListenersRef.current) {
@@ -237,9 +242,26 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
       songId?: string;
       songUrl?: string;
       musicSource?: MusicSource;
+      lyricsTimingOffsetMs?: number;
     }) => {
       const source = info.musicSource || "spotify";
       const nextAppleTrackId = source === "apple" ? info.songId || null : null;
+      const nextLyricsTimingSongKey = [
+        source,
+        info.songId || "",
+        info.songTitle,
+        info.artist,
+      ].join("|");
+
+      if (
+        typeof info.lyricsTimingOffsetMs === "number" &&
+        Number.isFinite(info.lyricsTimingOffsetMs)
+      ) {
+        setLyricsTimingOffsetMs(info.lyricsTimingOffsetMs);
+      } else if (lyricsTimingSongKeyRef.current !== nextLyricsTimingSongKey) {
+        setLyricsTimingOffsetMs(0);
+      }
+      lyricsTimingSongKeyRef.current = nextLyricsTimingSongKey;
 
       setAlbumArt(info.albumArt);
       setSongTitle(info.songTitle);
@@ -450,6 +472,8 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
     setMusicSource("spotify");
     setAppleTrackId(null);
     setTimedLyrics([]);
+    setLyricsTimingOffsetMs(0);
+    lyricsTimingSongKeyRef.current = null;
     setIsPlayingState(false);
     setCurrentTime(0);
     setDuration(0);
@@ -472,6 +496,7 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
     musicSource,
     appleTrackId,
     timedLyrics,
+    lyricsTimingOffsetMs,
     isPlaying: isPlayingState,
     currentTime,
     duration,
@@ -488,6 +513,7 @@ export function MusicPlayerProvider({ children }: { children: ReactNode }) {
     onStateChange,
     clearPlayer,
     setTimedLyrics,
+    setLyricsTimingOffsetMs,
   };
 
   return (

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.73",
+    date: "2026-06-02",
+    changes: [
+      {
+        type: "feature",
+        title: "Song Lyrics Timing Offset",
+        description:
+          "Synced song lyrics now include an optional per-song delay control for matching videos with intros or timing differences.",
+      },
+    ],
+  },
+  {
     version: "1.2.72",
     date: "2026-06-01",
     changes: [


### PR DESCRIPTION
## Summary
- Add a per-song lyrics timing control for synced song lyrics
- Allow users to delay or advance lyrics in 0.5s steps, up to +/-60s
- Apply the offset to lyric highlighting, autoscroll, tap-to-seek, and expanded mini-player lyrics
- Persist the offset only for the current song
