### PR TITLE
[Feature] Use level timing exclusions in level-up estimates

### DIFF
--- a/src/components/LevelTimingChart.tsx
+++ b/src/components/LevelTimingChart.tsx
@@ -1,5 +1,4 @@
 import { Ionicons } from "@expo/vector-icons";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dimensions, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import Animated, { Easing, FadeInDown, Layout } from "react-native-reanimated";
@@ -7,6 +6,13 @@ import {
   DEFAULT_ANALYTICS_WIDGET_STYLE_COLORS,
   normalizeAnalyticsWidgetColor,
 } from "../utils/analyticsWidgetStyles";
+import {
+  areLevelTimingExcludedLevelsEqual,
+  loadLevelTimingExcludedLevels,
+  normalizeLevelTimingExcludedLevels,
+  saveLevelTimingExcludedLevels,
+  subscribeLevelTimingExcludedLevels,
+} from "../utils/levelTimingExclusions";
 import { buildResetAwareLevelTimingData } from "../utils/levelProgress";
 import { withAlpha } from "../utils/subjectColors";
 import { useAuthStore, useSettingsStore } from "../utils/store";
@@ -34,25 +40,6 @@ type LevelTimingChartProps = {
   levelProgressions: any[];
   resets?: any[];
   currentLevel?: number;
-};
-
-const LEVEL_TIMING_DISABLED_STORAGE_KEY_PREFIX =
-  "wanikani_level_timing_disabled_levels_v1";
-
-const normalizeLevelList = (value: unknown): number[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const unique = new Set<number>();
-  for (const entry of value) {
-    const parsed = Number(entry);
-    if (Number.isFinite(parsed) && parsed >= 1) {
-      unique.add(Math.trunc(parsed));
-    }
-  }
-
-  return Array.from(unique).sort((a, b) => a - b);
 };
 
 // Convert numbers to Japanese kanji
@@ -184,11 +171,6 @@ export default function LevelTimingChart({
   const BAR_WIDTH = isTablet ? 36 : "80%";
   const LABEL_FONT_size = isTablet ? 13 : 11;
   const VALUE_FONT_SIZE = isTablet ? 12 : 10;
-  const storageKey = useMemo(
-    () =>
-      `${LEVEL_TIMING_DISABLED_STORAGE_KEY_PREFIX}:${authUserId ?? "anonymous"}`,
-    [authUserId],
-  );
 
   // Process level progressions to extract timing data
   const levelTimingData: LevelTimingData[] = useMemo(() => {
@@ -255,18 +237,12 @@ export default function LevelTimingChart({
 
     const loadDisabledLevels = async () => {
       try {
-        const raw = await AsyncStorage.getItem(storageKey);
+        const levels = await loadLevelTimingExcludedLevels(authUserId);
         if (isCancelled) {
           return;
         }
 
-        if (!raw) {
-          setDisabledLevels([]);
-          return;
-        }
-
-        const parsed = JSON.parse(raw);
-        setDisabledLevels(normalizeLevelList(parsed));
+        setDisabledLevels(levels);
       } catch (error) {
         console.warn("Failed to load level timing excluded levels", error);
         if (!isCancelled) {
@@ -284,19 +260,35 @@ export default function LevelTimingChart({
     return () => {
       isCancelled = true;
     };
-  }, [storageKey]);
+  }, [authUserId]);
 
   useEffect(() => {
     if (!disabledLevelsHydrated) {
       return;
     }
 
-    AsyncStorage.setItem(storageKey, JSON.stringify(disabledLevels)).catch(
-      (error) => {
-        console.warn("Failed to save level timing excluded levels", error);
-      },
+    saveLevelTimingExcludedLevels(authUserId, disabledLevels).catch((error) => {
+      console.warn("Failed to save level timing excluded levels", error);
+    });
+  }, [authUserId, disabledLevels, disabledLevelsHydrated]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeLevelTimingExcludedLevels(
+      (changedUserId, levels) => {
+        if ((changedUserId ?? "anonymous") !== (authUserId ?? "anonymous")) {
+          return;
+        }
+
+        setDisabledLevels((current) =>
+          areLevelTimingExcludedLevelsEqual(current, levels)
+            ? current
+            : normalizeLevelTimingExcludedLevels(levels)
+        );
+      }
     );
-  }, [disabledLevels, disabledLevelsHydrated, storageKey]);
+
+    return unsubscribe;
+  }, [authUserId]);
 
   const toggleableCompletedLevelSet = useMemo(() => {
     const levels = new Set<number>();

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -65,6 +65,12 @@ export const PATCH_NOTES: PatchNote[] = [
         description:
           "Added Spotify account connection, Spotify playback from song lyrics, and playlist importing for Spotify and Apple Music.",
       },
+      {
+        type: "fix",
+        title: "Level-Up Estimate Exclusions",
+        description:
+          "Level Up In estimates now respect levels ignored in Level Timing, keeping long outliers from skewing the countdown.",
+      },
     ],
   },
   {

--- a/src/hooks/useDashboardData.tsx
+++ b/src/hooks/useDashboardData.tsx
@@ -49,6 +49,11 @@ import {
   formatTimeInterval,
 } from "../utils/levelProgress";
 import {
+  areLevelTimingExcludedLevelsEqual,
+  loadLevelTimingExcludedLevels,
+  subscribeLevelTimingExcludedLevels,
+} from "../utils/levelTimingExclusions";
+import {
   getFullDashboardDataFromPermanentStorage,
   saveAssignmentsToPermanentStorage,
 } from "../utils/permanentStorage";
@@ -158,6 +163,96 @@ const initialDashboardData: DashboardDataType = {
   },
 };
 
+function calculateDashboardLevelTimeRemaining({
+  assignments,
+  subjects,
+  levelProgressions,
+  resets,
+  currentLevel,
+  excludedLevels,
+}: {
+  assignments: any[];
+  subjects: any[];
+  levelProgressions: any[];
+  resets: any[];
+  currentLevel: number;
+  excludedLevels: readonly number[];
+}): DashboardDataType["levelTimeRemaining"] {
+  const subjectsById: Record<number, any> = {};
+  const currentLevelSubjectsById: Record<number, any> = {};
+
+  for (const subject of subjects) {
+    subjectsById[subject.id] = subject;
+    if (subject.data.level === currentLevel) {
+      currentLevelSubjectsById[subject.id] = subject;
+    }
+  }
+
+  const currentLevelAssignments = assignments.filter((assignment) => {
+    return subjectsById[assignment.data.subject_id]?.data.level === currentLevel;
+  });
+
+  const enhancedAssignments = currentLevelAssignments.map((assignment) => {
+    const subject = currentLevelSubjectsById[assignment.data.subject_id];
+    const isLocked = !assignment.data.unlocked_at;
+
+    return {
+      ...assignment,
+      subject,
+      isLocked,
+    };
+  });
+
+  const assignedSubjectIds = new Set(
+    currentLevelAssignments.map((assignment) => assignment.data.subject_id)
+  );
+  const lockedKanjiEntries = Object.values(currentLevelSubjectsById)
+    .filter(
+      (subject: any) =>
+        subject.object === "kanji" &&
+        !subject.data.hidden_at &&
+        !assignedSubjectIds.has(subject.id)
+    )
+    .map((subject: any) => ({
+      id: -subject.id,
+      object: "assignment",
+      url: "",
+      data_updated_at: "",
+      data: {
+        created_at: "",
+        subject_type: "kanji" as const,
+        subject_id: subject.id,
+        unlocked_at: null,
+        started_at: null,
+        passed_at: null,
+        burned_at: null,
+        available_at: null,
+        resurrected_at: null,
+        hidden: false,
+        srs_stage: 0,
+      },
+      subject,
+      isLocked: true,
+    }));
+
+  const allLevelAssignments = [
+    ...enhancedAssignments,
+    ...lockedKanjiEntries,
+  ];
+
+  const { finish, isEstimate } = calculateLevelTimeRemaining(
+    allLevelAssignments,
+    levelProgressions,
+    resets,
+    { excludedLevels, currentLevel }
+  );
+
+  const timeText =
+    finish <= new Date() ? "Now" : formatTimeInterval(finish);
+
+  return { timeText, isEstimate };
+}
+
 interface DashboardContextType {
   dashboardData: DashboardDataType;
   isLoading: boolean;
@@ -253,6 +348,7 @@ const DashboardContext = createContext<DashboardContextType>({
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const { apiToken, setUserData, setLearnedKanjiCount, lastWrappedLevel, setLastWrappedLevel } =
     useAuthStore();
+  const authUserId = useAuthStore((state) => state.userData?.id ?? null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingStage, setLoadingStage] = useState<LoadingStage>(
     LoadingStage.IDLE
@@ -263,6 +359,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const dashboardDataRef = useRef(dashboardData);
   dashboardDataRef.current = dashboardData;
   const [isFreshData, setIsFreshData] = useState(false);
+  const [levelTimingExcludedLevels, setLevelTimingExcludedLevels] = useState<
+    number[]
+  >([]);
   const startupDashboardFetchTrackedRef = useRef(false);
   const dashboardForegroundFetchInFlightRef = useRef(false);
   const dashboardBackgroundRefreshInFlightRef = useRef(false);
@@ -274,6 +373,85 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   // Calculate loading progress based on current stage
   const loadingProgress = loadingStage / TOTAL_LOADING_STAGES;
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    loadLevelTimingExcludedLevels(authUserId)
+      .then((levels) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setLevelTimingExcludedLevels((current) =>
+          areLevelTimingExcludedLevelsEqual(current, levels) ? current : levels
+        );
+      })
+      .catch((error) => {
+        console.warn("Failed to load level timing excluded levels:", error);
+        if (!isCancelled) {
+          setLevelTimingExcludedLevels([]);
+        }
+      });
+
+    const unsubscribe = subscribeLevelTimingExcludedLevels(
+      (changedUserId, levels) => {
+        if ((changedUserId ?? "anonymous") !== (authUserId ?? "anonymous")) {
+          return;
+        }
+
+        setLevelTimingExcludedLevels((current) =>
+          areLevelTimingExcludedLevelsEqual(current, levels) ? current : levels
+        );
+      }
+    );
+
+    return () => {
+      isCancelled = true;
+      unsubscribe();
+    };
+  }, [authUserId]);
+
+  useEffect(() => {
+    setDashboardData((prev) => {
+      if (
+        !prev.dataLoadingState.levelData ||
+        !prev.dataLoadingState.subjects ||
+        prev.subjects.length === 0
+      ) {
+        return prev;
+      }
+
+      try {
+        const levelTimeRemaining = calculateDashboardLevelTimeRemaining({
+          assignments: prev.assignments,
+          subjects: prev.subjects,
+          levelProgressions: prev.levelProgressions,
+          resets: prev.resets,
+          currentLevel: prev.currentLevel,
+          excludedLevels: levelTimingExcludedLevels,
+        });
+
+        if (
+          prev.levelTimeRemaining.timeText === levelTimeRemaining.timeText &&
+          prev.levelTimeRemaining.isEstimate === levelTimeRemaining.isEstimate
+        ) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          levelTimeRemaining,
+        };
+      } catch (error) {
+        console.warn(
+          "Error recalculating level time remaining after exclusions changed:",
+          error
+        );
+        return prev;
+      }
+    });
+  }, [levelTimingExcludedLevels]);
 
   const loadPendingProgressAssignmentIds = useCallback(
     async (): Promise<PendingProgressAssignmentIds> => {
@@ -753,101 +931,22 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         };
 
         try {
-          // Get the current level assignments
           const currentLevelValue = userData.data.level;
+          const excludedLevels = await loadLevelTimingExcludedLevels(userData.data.id);
+          setLevelTimingExcludedLevels((current) =>
+            areLevelTimingExcludedLevelsEqual(current, excludedLevels)
+              ? current
+              : excludedLevels
+          );
 
-          const currentLevelAssignments = assignments.data.filter((a) => {
-            // Find the subject for this assignment
-            const subject = allSubjects.find((s) => s.id === a.data.subject_id);
-            // Check if it's from the current level
-            return subject && subject.data.level === currentLevelValue;
+          levelTimeRemainingData = calculateDashboardLevelTimeRemaining({
+            assignments: assignments.data,
+            subjects: allSubjects,
+            levelProgressions: levelProgressions.data,
+            resets: resets.data,
+            currentLevel: currentLevelValue,
+            excludedLevels,
           });
-
-          // Ensure we have the complete subject data for each assignment
-          const currentLevelSubjectsById = allSubjects.reduce(
-            (acc, subject) => {
-              if (subject.data.level === currentLevelValue) {
-                acc[subject.id] = subject;
-              }
-              return acc;
-            },
-            {} as Record<number, any>
-          );
-
-          // Enhance assignments with their full subject data
-          // In Swift, the isLocked property is used to determine if a kanji is locked
-          const enhancedAssignments = currentLevelAssignments.map(
-            (assignment) => {
-              const subject =
-                currentLevelSubjectsById[assignment.data.subject_id];
-
-              // In Swift's assignment class, isLocked means the item isn't unlocked yet
-              // This is different from "started" which means it has been started in lessons
-              const isLocked = !assignment.data.unlocked_at;
-
-              return {
-                ...assignment,
-                // Attach the subject data to match the Swift implementation
-                subject: subject,
-                // Set isLocked property to match Swift's definition
-                isLocked: isLocked,
-              };
-            }
-          );
-
-          // The WaniKani API only returns assignments for unlocked subjects.
-          // Kanji that are still locked (waiting for radicals to guru) have no
-          // assignment at all, so synthesize locked entries here to avoid
-          // underestimating level-up time.
-          const assignedSubjectIds = new Set(
-            currentLevelAssignments.map((a) => a.data.subject_id)
-          );
-          const lockedKanjiEntries = Object.values(currentLevelSubjectsById)
-            .filter(
-              (subject: any) =>
-                subject.object === "kanji" &&
-                !subject.data.hidden_at &&
-                !assignedSubjectIds.has(subject.id)
-            )
-            .map((subject: any) => ({
-              id: -subject.id,
-              object: "assignment",
-              url: "",
-              data_updated_at: "",
-              data: {
-                created_at: "",
-                subject_type: "kanji" as const,
-                subject_id: subject.id,
-                unlocked_at: null,
-                started_at: null,
-                passed_at: null,
-                burned_at: null,
-                available_at: null,
-                resurrected_at: null,
-                hidden: false,
-                srs_stage: 0,
-              },
-              subject,
-              isLocked: true,
-            }));
-
-          const allLevelAssignments = [
-            ...enhancedAssignments,
-            ...lockedKanjiEntries,
-          ];
-
-          // Now call the level time remaining calculator
-          const { finish, isEstimate } = calculateLevelTimeRemaining(
-            allLevelAssignments,
-            levelProgressions.data,
-            resets.data
-          );
-
-          // Format the finish date into a time text
-          const timeText =
-            finish <= new Date() ? "Now" : formatTimeInterval(finish);
-
-          levelTimeRemainingData = { timeText, isEstimate };
         } catch (error) {
           console.warn("Error calculating level time remaining:", error);
           levelTimeRemainingData = {

--- a/src/utils/__tests__/levelTimeRemaining.test.ts
+++ b/src/utils/__tests__/levelTimeRemaining.test.ts
@@ -191,6 +191,41 @@ describe("calculateLevelTimeRemaining", () => {
     expect(isEstimate).toBe(true);
     expect(finish.toISOString()).toBe("2026-02-24T23:34:00.000Z");
   });
+
+  it("ignores excluded historical levels for locked-kanji estimates", () => {
+    const lockedKanji = makeSubject(30, 5, "kanji");
+    const assignments: TestAssignment[] = [
+      makeAssignment({
+        id: 30,
+        subjectId: lockedKanji.id,
+        subjectType: "kanji",
+        srsStage: 0,
+        availableAt: null,
+        unlockedAt: null,
+        startedAt: null,
+        isLocked: true,
+        subject: lockedKanji,
+      }),
+    ];
+
+    const levelProgressions = [
+      { data: { level: 1, timeSpentCurrent: 10 * 24 * 60 * 60 } },
+      { data: { level: 2, timeSpentCurrent: 12 * 24 * 60 * 60 } },
+      { data: { level: 3, timeSpentCurrent: 120 * 24 * 60 * 60 } },
+      { data: { level: 4, timeSpentCurrent: 14 * 24 * 60 * 60 } },
+      { data: { level: 5, timeSpentCurrent: 4 * 24 * 60 * 60 } },
+    ];
+
+    const { finish, isEstimate } = calculateLevelTimeRemaining(
+      assignments,
+      levelProgressions,
+      [],
+      { currentLevel: 5, excludedLevels: [3] }
+    );
+
+    expect(isEstimate).toBe(true);
+    expect(finish.toISOString()).toBe("2026-03-04T10:34:00.000Z");
+  });
 });
 
 describe("formatTimeInterval", () => {

--- a/src/utils/levelProgress.ts
+++ b/src/utils/levelProgress.ts
@@ -43,6 +43,11 @@ export type WkstatsLevelTimingSummary = {
   levelUpInDays: number;
 };
 
+export type LevelTimeRemainingCalculationOptions = {
+  excludedLevels?: readonly number[];
+  currentLevel?: number;
+};
+
 function parseTimestamp(value: string | null | undefined): number | null {
   if (!value) {
     return null;
@@ -385,7 +390,8 @@ function getResetAwareLevelProgressions(
 export function calculateLevelTimeRemaining(
   assignments: LevelAssignment[],
   allLevelProgressions: any[],
-  resets: any[] = []
+  resets: any[] = [],
+  options: LevelTimeRemainingCalculationOptions = {}
 ): { finish: Date; isEstimate: boolean } {
   const radicalDates: Date[] = [];
   const guruDates: Date[] = [];
@@ -466,7 +472,8 @@ export function calculateLevelTimeRemaining(
   if (lastGuruDate.getTime() === DISTANT_FUTURE && lastSubject) {
     let average = calculateAverageLevelTimeRemaining(
       allLevelProgressions,
-      resets
+      resets,
+      options
     );
 
     // Floor estimate at minimum apprentice-to-guru time for a fresh item plus
@@ -556,7 +563,8 @@ function apprenticeStageDurationSeconds(subject: Subject, stage: number): number
  */
 function calculateAverageLevelTimeRemaining(
   levelProgressions: any[],
-  resets: any[] = []
+  resets: any[] = [],
+  options: LevelTimeRemainingCalculationOptions = {}
 ): number {
   const hasLevelMetadata = (levelProgressions ?? []).some((level) => {
     const normalized = level?.data ?? level;
@@ -568,8 +576,40 @@ function calculateAverageLevelTimeRemaining(
     ? getResetAwareLevelProgressions(levelProgressions, resets)
     : levelProgressions ?? [];
   const timeSpentAtEachLevel: number[] = [];
+  const excludedLevelSet = new Set<number>();
 
-  for (const level of resetAwareProgressions) {
+  for (const level of options.excludedLevels ?? []) {
+    const parsedLevel = Number(level);
+    if (Number.isFinite(parsedLevel) && parsedLevel >= 1) {
+      excludedLevelSet.add(Math.trunc(parsedLevel));
+    }
+  }
+
+  const currentLevel = Number.isFinite(options.currentLevel)
+    ? Math.trunc(Number(options.currentLevel))
+    : null;
+
+  for (let index = 0; index < resetAwareProgressions.length; index += 1) {
+    const level = resetAwareProgressions[index];
+    const normalized = level?.data ?? level;
+    const progressionLevel = Number(normalized?.level);
+    const hasProgressionLevel = Number.isFinite(progressionLevel);
+    const normalizedProgressionLevel = hasProgressionLevel
+      ? Math.trunc(progressionLevel)
+      : null;
+    const isCurrentLevelProgression =
+      currentLevel !== null
+        ? normalizedProgressionLevel === currentLevel
+        : index === resetAwareProgressions.length - 1;
+
+    if (
+      normalizedProgressionLevel !== null &&
+      excludedLevelSet.has(normalizedProgressionLevel) &&
+      !isCurrentLevelProgression
+    ) {
+      continue;
+    }
+
     const timeSpentCurrent = getTimeSpentCurrent(level);
     if (timeSpentCurrent > 0) {
       timeSpentAtEachLevel.push(timeSpentCurrent);

--- a/src/utils/levelTimingExclusions.ts
+++ b/src/utils/levelTimingExclusions.ts
@@ -1,0 +1,86 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export const LEVEL_TIMING_EXCLUDED_STORAGE_KEY_PREFIX =
+  "wanikani_level_timing_disabled_levels_v1";
+
+type LevelTimingExcludedLevelsListener = (
+  userId: string | null,
+  levels: number[]
+) => void;
+
+const listeners = new Set<LevelTimingExcludedLevelsListener>();
+
+export function normalizeLevelTimingExcludedLevels(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const unique = new Set<number>();
+  for (const entry of value) {
+    const parsed = Number(entry);
+    if (Number.isFinite(parsed) && parsed >= 1) {
+      unique.add(Math.trunc(parsed));
+    }
+  }
+
+  return Array.from(unique).sort((a, b) => a - b);
+}
+
+export function areLevelTimingExcludedLevelsEqual(
+  left: readonly number[],
+  right: readonly number[]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+export function getLevelTimingExcludedStorageKey(
+  userId: string | null | undefined
+): string {
+  return `${LEVEL_TIMING_EXCLUDED_STORAGE_KEY_PREFIX}:${userId ?? "anonymous"}`;
+}
+
+function notifyLevelTimingExcludedLevelsChanged(
+  userId: string | null,
+  levels: number[]
+) {
+  for (const listener of listeners) {
+    listener(userId, levels);
+  }
+}
+
+export function subscribeLevelTimingExcludedLevels(
+  listener: LevelTimingExcludedLevelsListener
+): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadLevelTimingExcludedLevels(
+  userId: string | null | undefined
+): Promise<number[]> {
+  const raw = await AsyncStorage.getItem(getLevelTimingExcludedStorageKey(userId));
+  if (!raw) {
+    return [];
+  }
+
+  return normalizeLevelTimingExcludedLevels(JSON.parse(raw));
+}
+
+export async function saveLevelTimingExcludedLevels(
+  userId: string | null | undefined,
+  levels: readonly number[]
+): Promise<void> {
+  const normalizedLevels = normalizeLevelTimingExcludedLevels([...levels]);
+  await AsyncStorage.setItem(
+    getLevelTimingExcludedStorageKey(userId),
+    JSON.stringify(normalizedLevels)
+  );
+  notifyLevelTimingExcludedLevelsChanged(userId ?? null, normalizedLevels);
+}


### PR DESCRIPTION
## Summary
- Connect Level Timing excluded levels to the Level Up In estimate
- Recalculate the dashboard estimate when excluded levels change
- Add regression coverage for locked-kanji estimates with excluded historical outliers

