### PR TITLE
[Fix] Reduce Random Test Word Repetition

### DIFF
--- a/app/(app)/test-session.tsx
+++ b/app/(app)/test-session.tsx
@@ -30,6 +30,12 @@ import {
   loadExtraStudySessionState,
   saveExtraStudySessionState,
 } from "../../src/utils/extraStudySessionPersistence";
+import {
+  getRecentRandomTestSubjectIds,
+  loadRandomTestSubjectHistory,
+  saveRandomTestSubjectHistoryEntry,
+  selectRandomTestSubjects,
+} from "../../src/utils/randomTestHistory";
 import { buildReviewQuestionQueue } from "../../src/utils/reviewOrdering";
 import { useAuthStore, useSettingsStore } from "../../src/utils/store";
 import { useTheme } from "../../src/utils/theme";
@@ -325,6 +331,9 @@ const buildRandomTestSession = (
   subjects: ApiSubject[],
   config: TestSessionConfig,
   queueBehavior: RandomQueueBehaviorOptions,
+  selectionOptions: {
+    avoidSubjectIds?: ReadonlySet<number>;
+  } = {},
 ): {
   questions: TestQuestion[];
   reviewItems: RandomTestReviewItem[];
@@ -338,15 +347,9 @@ const buildRandomTestSession = (
   }
 
   const maxSubjects = Math.min(config.numberOfQuestions, candidates.length);
-  const pool = [...candidates];
-
-  // Select random unique subjects with unbiased partial Fisher–Yates.
-  for (let i = 0; i < maxSubjects; i++) {
-    const randomIndex = i + Math.floor(Math.random() * (pool.length - i));
-    [pool[i], pool[randomIndex]] = [pool[randomIndex], pool[i]];
-  }
-
-  const selectedSubjects = pool.slice(0, maxSubjects);
+  const selectedSubjects = selectRandomTestSubjects(candidates, maxSubjects, {
+    avoidSubjectIds: selectionOptions.avoidSubjectIds,
+  });
   const questions: TestQuestion[] = [];
   const reviewItems: RandomTestReviewItem[] = [];
   const subjectById = new Map<number, ApiSubject>();
@@ -729,9 +732,48 @@ export default function TestSessionScreen() {
       return;
     }
 
+    const loadRecentRandomTestSubjectIds = async (): Promise<Set<number>> => {
+      if (isHiraganaVocabMeaningMode) {
+        return new Set();
+      }
+
+      try {
+        const history = await loadRandomTestSubjectHistory();
+        return new Set(getRecentRandomTestSubjectIds(history));
+      } catch (historyError) {
+        console.warn(
+          "Random Test: failed to load recent subject history",
+          historyError,
+        );
+        return new Set();
+      }
+    };
+
+    const saveGeneratedRandomTestHistory = async (
+      items: RandomTestReviewItem[],
+    ): Promise<void> => {
+      if (isHiraganaVocabMeaningMode) {
+        return;
+      }
+
+      try {
+        await saveRandomTestSubjectHistoryEntry(
+          items.map((item) => item.subjectId),
+        );
+      } catch (historyError) {
+        console.warn(
+          "Random Test: failed to save recent subject history",
+          historyError,
+        );
+      }
+    };
+
+    let avoidRecentRandomTestSubjectIds = new Set<number>();
+
     try {
       setIsLoading(true);
       await clearSavedRandomTestSession();
+      avoidRecentRandomTestSubjectIds = await loadRecentRandomTestSubjectIds();
 
       let assignmentsResponse: { data: Assignment[] } | null = null;
       try {
@@ -864,7 +906,9 @@ export default function TestSessionScreen() {
       };
 
       const { questions, reviewItems: generatedReviewItems } =
-        buildRandomTestSession(filteredSubjects, config, queueBehavior);
+        buildRandomTestSession(filteredSubjects, config, queueBehavior, {
+          avoidSubjectIds: avoidRecentRandomTestSubjectIds,
+        });
       const reviewItemsWithSrs = generatedReviewItems.map((reviewItem) => ({
         ...reviewItem,
         srsStage: subjectIdToStage.get(reviewItem.subjectId),
@@ -879,6 +923,7 @@ export default function TestSessionScreen() {
         return;
       }
 
+      await saveGeneratedRandomTestHistory(reviewItemsWithSrs);
       initializeSessionState(questions, reviewItemsWithSrs);
     } catch (error) {
       console.warn("Falling back to offline subjects-only mode due to error:", error);
@@ -979,7 +1024,9 @@ export default function TestSessionScreen() {
         };
 
         const { questions, reviewItems: generatedReviewItems } =
-          buildRandomTestSession(filteredSubjects, config, queueBehavior);
+          buildRandomTestSession(filteredSubjects, config, queueBehavior, {
+            avoidSubjectIds: avoidRecentRandomTestSubjectIds,
+          });
 
         if (questions.length === 0) {
           Alert.alert(
@@ -990,6 +1037,7 @@ export default function TestSessionScreen() {
           return;
         }
 
+        await saveGeneratedRandomTestHistory(generatedReviewItems);
         initializeSessionState(questions, generatedReviewItems);
       } catch (fallbackError) {
         console.error("Offline fallback failed:", fallbackError);

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -71,6 +71,12 @@ export const PATCH_NOTES: PatchNote[] = [
         description:
           "Level Up In estimates now respect levels ignored in Level Timing, keeping long outliers from skewing the countdown.",
       },
+      {
+        type: "fix",
+        title: "Fresher Random Tests",
+        description:
+          "Random Test now avoids reusing subjects from recent tests when enough fresh items are available.",
+      },
     ],
   },
   {

--- a/src/utils/__tests__/randomTestHistory.test.ts
+++ b/src/utils/__tests__/randomTestHistory.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  RANDOM_TEST_HISTORY_SESSION_LIMIT,
+  RANDOM_TEST_SUBJECT_HISTORY_STORAGE_KEY,
+  getRecentRandomTestSubjectIds,
+  sanitizeRandomTestSubjectHistory,
+  saveRandomTestSubjectHistoryEntry,
+  selectRandomTestSubjects,
+} from "../randomTestHistory";
+
+interface TestSubject {
+  id: number;
+}
+
+function makeSubjects(ids: number[]): TestSubject[] {
+  return ids.map((id) => ({ id }));
+}
+
+const mockedAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe("randomTestHistory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sanitizes persisted history entries", () => {
+    const history = sanitizeRandomTestSubjectHistory(
+      [
+        { generatedAt: 300, subjectIds: [1, 2, 2, Number.NaN, -1] },
+        { generatedAt: "bad", subjectIds: [3] },
+        { generatedAt: 100, subjectIds: [] },
+        null,
+      ],
+      2
+    );
+
+    expect(history).toEqual([
+      { generatedAt: 300, subjectIds: [1, 2] },
+      { generatedAt: 0, subjectIds: [3] },
+    ]);
+  });
+
+  it("returns recent subject ids newest-first without duplicates", () => {
+    const recentSubjectIds = getRecentRandomTestSubjectIds([
+      { generatedAt: 300, subjectIds: [1, 2, 3] },
+      { generatedAt: 200, subjectIds: [3, 4] },
+      { generatedAt: 100, subjectIds: [5] },
+    ]);
+
+    expect(recentSubjectIds).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("selects only fresh subjects when enough are available", () => {
+    const selected = selectRandomTestSubjects(makeSubjects([1, 2, 3, 4, 5, 6]), 3, {
+      avoidSubjectIds: new Set([1, 2, 3]),
+      randomFn: () => 0.5,
+    });
+
+    expect(selected).toHaveLength(3);
+    expect(selected.map((subject) => subject.id).sort()).toEqual([4, 5, 6]);
+  });
+
+  it("fills from recent subjects only after using every fresh subject", () => {
+    const selected = selectRandomTestSubjects(makeSubjects([1, 2, 3, 4, 5, 6]), 4, {
+      avoidSubjectIds: new Set([1, 2, 3, 4]),
+      randomFn: () => 0.5,
+    });
+    const selectedIds = selected.map((subject) => subject.id);
+
+    expect(selected).toHaveLength(4);
+    expect(selectedIds).toEqual(expect.arrayContaining([5, 6]));
+    expect(selectedIds.filter((id) => id <= 4)).toHaveLength(2);
+  });
+
+  it("saves a bounded newest-first history entry", async () => {
+    mockedAsyncStorage.getItem.mockResolvedValue(
+      JSON.stringify(
+        Array.from({ length: RANDOM_TEST_HISTORY_SESSION_LIMIT }, (_, index) => ({
+          generatedAt: index + 1,
+          subjectIds: [index + 10],
+        }))
+      )
+    );
+
+    await saveRandomTestSubjectHistoryEntry([1, 2, 2], 999);
+
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+      RANDOM_TEST_SUBJECT_HISTORY_STORAGE_KEY,
+      expect.any(String)
+    );
+
+    const savedHistory = JSON.parse(
+      mockedAsyncStorage.setItem.mock.calls[0][1]
+    );
+    expect(savedHistory).toHaveLength(RANDOM_TEST_HISTORY_SESSION_LIMIT);
+    expect(savedHistory[0]).toEqual({ generatedAt: 999, subjectIds: [1, 2] });
+  });
+});

--- a/src/utils/randomTestHistory.ts
+++ b/src/utils/randomTestHistory.ts
@@ -1,0 +1,160 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export const RANDOM_TEST_SUBJECT_HISTORY_STORAGE_KEY =
+  "extra_study_random_test_subject_history_v1";
+export const RANDOM_TEST_HISTORY_SESSION_LIMIT = 5;
+
+export interface RandomTestSubjectHistoryEntry {
+  generatedAt: number;
+  subjectIds: number[];
+}
+
+interface RandomTestSelectableSubject {
+  id: number;
+}
+
+function normalizeSubjectIds(values: unknown): number[] {
+  if (!Array.isArray(values)) return [];
+
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    const subjectId = Math.floor(value);
+    if (subjectId <= 0 || seen.has(subjectId)) continue;
+    seen.add(subjectId);
+    out.push(subjectId);
+  }
+  return out;
+}
+
+export function sanitizeRandomTestSubjectHistory(
+  value: unknown,
+  limit = RANDOM_TEST_HISTORY_SESSION_LIMIT
+): RandomTestSubjectHistoryEntry[] {
+  if (!Array.isArray(value)) return [];
+
+  const out: RandomTestSubjectHistoryEntry[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+
+    const subjectIds = normalizeSubjectIds(
+      (entry as Partial<RandomTestSubjectHistoryEntry>).subjectIds
+    );
+    if (subjectIds.length === 0) continue;
+
+    const generatedAt = (entry as Partial<RandomTestSubjectHistoryEntry>)
+      .generatedAt;
+    out.push({
+      generatedAt:
+        typeof generatedAt === "number" && Number.isFinite(generatedAt)
+          ? generatedAt
+          : 0,
+      subjectIds,
+    });
+
+    if (out.length >= limit) break;
+  }
+
+  return out;
+}
+
+export async function loadRandomTestSubjectHistory(): Promise<
+  RandomTestSubjectHistoryEntry[]
+> {
+  const rawValue = await AsyncStorage.getItem(
+    RANDOM_TEST_SUBJECT_HISTORY_STORAGE_KEY
+  );
+  if (!rawValue) return [];
+
+  try {
+    return sanitizeRandomTestSubjectHistory(JSON.parse(rawValue));
+  } catch {
+    return [];
+  }
+}
+
+export async function saveRandomTestSubjectHistoryEntry(
+  subjectIds: number[],
+  generatedAt = Date.now()
+): Promise<void> {
+  const normalizedSubjectIds = normalizeSubjectIds(subjectIds);
+  if (normalizedSubjectIds.length === 0) return;
+
+  const history = await loadRandomTestSubjectHistory();
+  const nextHistory = sanitizeRandomTestSubjectHistory([
+    { generatedAt, subjectIds: normalizedSubjectIds },
+    ...history,
+  ]);
+
+  await AsyncStorage.setItem(
+    RANDOM_TEST_SUBJECT_HISTORY_STORAGE_KEY,
+    JSON.stringify(nextHistory)
+  );
+}
+
+export function getRecentRandomTestSubjectIds(
+  history: RandomTestSubjectHistoryEntry[],
+  sessionLimit = RANDOM_TEST_HISTORY_SESSION_LIMIT
+): number[] {
+  const seen = new Set<number>();
+  const out: number[] = [];
+
+  for (const entry of history.slice(0, sessionLimit)) {
+    for (const subjectId of entry.subjectIds) {
+      if (seen.has(subjectId)) continue;
+      seen.add(subjectId);
+      out.push(subjectId);
+    }
+  }
+
+  return out;
+}
+
+function sampleSubjects<T>(
+  subjects: T[],
+  count: number,
+  randomFn: () => number
+): T[] {
+  const pool = [...subjects];
+  const maxSubjects = Math.min(Math.max(0, Math.floor(count)), pool.length);
+
+  for (let i = 0; i < maxSubjects; i++) {
+    const randomIndex = i + Math.floor(randomFn() * (pool.length - i));
+    [pool[i], pool[randomIndex]] = [pool[randomIndex], pool[i]];
+  }
+
+  return pool.slice(0, maxSubjects);
+}
+
+export function selectRandomTestSubjects<T extends RandomTestSelectableSubject>(
+  subjects: T[],
+  count: number,
+  options: {
+    avoidSubjectIds?: ReadonlySet<number>;
+    randomFn?: () => number;
+  } = {}
+): T[] {
+  const maxSubjects = Math.min(Math.max(0, Math.floor(count)), subjects.length);
+  if (maxSubjects === 0) return [];
+
+  const avoidSubjectIds = options.avoidSubjectIds ?? new Set<number>();
+  const randomFn = options.randomFn ?? Math.random;
+  const freshSubjects = subjects.filter(
+    (subject) => !avoidSubjectIds.has(subject.id)
+  );
+
+  if (freshSubjects.length >= maxSubjects) {
+    return sampleSubjects(freshSubjects, maxSubjects, randomFn);
+  }
+
+  const recentSubjects = subjects.filter((subject) =>
+    avoidSubjectIds.has(subject.id)
+  );
+  const selectedSubjects = [
+    ...sampleSubjects(freshSubjects, freshSubjects.length, randomFn),
+    ...sampleSubjects(recentSubjects, maxSubjects - freshSubjects.length, randomFn),
+  ];
+
+  return sampleSubjects(selectedSubjects, selectedSubjects.length, randomFn);
+}


### PR DESCRIPTION
## Summary
- Track recently generated Random Test subjects.
- Prefer fresh eligible subjects when creating new Random Tests.
- Fall back to recent subjects only when the filtered pool is too small.
