### PR TITLE
[Feature] Add subject list sort options

### DIFF
--- a/app/(app)/subject-list/[id].tsx
+++ b/app/(app)/subject-list/[id].tsx
@@ -1,8 +1,8 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Ionicons } from "@expo/vector-icons";
-import { useFocusEffect } from "@react-navigation/native";
+import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -10,6 +10,8 @@ import {
   Image,
   Keyboard,
   Modal,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
   Platform,
   StyleSheet,
   Text,
@@ -75,6 +77,13 @@ const SELECTED_SUBJECT_SORT_SECTIONS = [
     options: SUBJECT_LIST_ITEM_SORT_OPTIONS,
   },
 ];
+type SubjectListEditorTab = "browse" | "selected";
+type PendingScrollRestore = {
+  tab: SubjectListEditorTab;
+  offset: number;
+  expiresAt: number;
+};
+const SCROLL_RESTORE_WINDOW_MS = 3000;
 
 function setsEqual(a: Set<number>, b: Set<number>): boolean {
   if (a.size !== b.size) return false;
@@ -90,6 +99,13 @@ export default function SubjectListEditorScreen() {
   const { apiToken } = useAuthStore();
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
+  const isFocused = useIsFocused();
+  const listRef = useRef<FlatList<Subject>>(null);
+  const scrollOffsetsRef = useRef<Record<SubjectListEditorTab, number>>({
+    browse: 0,
+    selected: 0,
+  });
+  const pendingScrollRestoreRef = useRef<PendingScrollRestore | null>(null);
 
   const [isLoadingList, setIsLoadingList] = useState(true);
   const [list, setList] = useState<SubjectList | null>(null);
@@ -104,7 +120,7 @@ export default function SubjectListEditorScreen() {
   const [isSaving, setIsSaving] = useState(false);
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [activeTab, setActiveTab] = useState<"browse" | "selected">("browse");
+  const [activeTab, setActiveTab] = useState<SubjectListEditorTab>("browse");
   const [showFilters, setShowFilters] = useState(false);
   const [showSelectedSortModal, setShowSelectedSortModal] = useState(false);
   const [selectedSubjectSortMode, setSelectedSubjectSortMode] =
@@ -337,6 +353,11 @@ export default function SubjectListEditorScreen() {
   };
 
   const handleSubjectTilePress = (subject: Subject) => {
+    pendingScrollRestoreRef.current = {
+      tab: activeTab,
+      offset: scrollOffsetsRef.current[activeTab],
+      expiresAt: Date.now() + SCROLL_RESTORE_WINDOW_MS,
+    };
     router.push(`/subject/${subject.id}`);
   };
 
@@ -390,6 +411,64 @@ export default function SubjectListEditorScreen() {
     selectedSubjectOrderIndex,
     selectedSubjectSortMode,
     subjectSrsStageMap,
+  ]);
+
+  const visibleSubjectCount =
+    activeTab === "browse" ? filteredSubjects.length : selectedSubjects.length;
+
+  const handleListScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollOffsetsRef.current[activeTab] = event.nativeEvent.contentOffset.y;
+    },
+    [activeTab]
+  );
+
+  const handleListScrollBeginDrag = useCallback(() => {
+    pendingScrollRestoreRef.current = null;
+  }, []);
+
+  const restoreListScrollIfNeeded = useCallback(() => {
+    const pendingRestore = pendingScrollRestoreRef.current;
+    if (!pendingRestore) {
+      return;
+    }
+
+    if (Date.now() > pendingRestore.expiresAt) {
+      pendingScrollRestoreRef.current = null;
+      return;
+    }
+
+    if (pendingRestore.tab !== activeTab || pendingRestore.offset <= 0) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      listRef.current?.scrollToOffset({
+        offset: pendingRestore.offset,
+        animated: false,
+      });
+    });
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (
+      !isFocused ||
+      isLoadingSubjects ||
+      isCacheMissing ||
+      isRebuildingCache ||
+      visibleSubjectCount === 0
+    ) {
+      return;
+    }
+
+    restoreListScrollIfNeeded();
+  }, [
+    isCacheMissing,
+    isFocused,
+    isLoadingSubjects,
+    isRebuildingCache,
+    restoreListScrollIfNeeded,
+    visibleSubjectCount,
   ]);
 
   const allMatchingSelected =
@@ -999,6 +1078,7 @@ export default function SubjectListEditorScreen() {
           </View>
         ) : (
           <FlatList
+            ref={listRef}
             data={activeTab === "browse" ? filteredSubjects : selectedSubjects}
             renderItem={
               activeTab === "browse"
@@ -1012,6 +1092,9 @@ export default function SubjectListEditorScreen() {
             ]}
             keyboardDismissMode="on-drag"
             keyboardShouldPersistTaps="handled"
+            onScroll={handleListScroll}
+            onScrollBeginDrag={handleListScrollBeginDrag}
+            scrollEventThrottle={16}
             ItemSeparatorComponent={() => <View style={{ height: 6 }} />}
             ListEmptyComponent={
               <View style={styles.emptyState}>

--- a/app/(app)/subject-list/[id].tsx
+++ b/app/(app)/subject-list/[id].tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -23,6 +24,7 @@ import {
   SearchFilterModal,
   SearchFilters,
 } from "../../../src/components/SearchFilterModal";
+import { CommonFilterModal } from "../../../src/components/CommonFilterModal";
 import { GlassButton } from "../../../src/components/GlassButton";
 import { WaniKaniItemType } from "../../../src/types/wanikani";
 import {
@@ -53,10 +55,26 @@ import {
 } from "../../../src/utils/subjectSearch";
 import { formatLevelWithSrsStage } from "../../../src/utils/srsStageLabel";
 import { useTheme } from "../../../src/utils/theme";
+import {
+  DEFAULT_SUBJECT_LIST_ITEM_SORT_MODE,
+  getSubjectListItemSortLabel,
+  isSubjectListItemSortMode,
+  sortSubjectListItems,
+  SUBJECT_LIST_ITEM_SORT_OPTIONS,
+  SUBJECT_LIST_ITEM_SORT_STORAGE_KEY,
+  SubjectListItemSortMode,
+} from "../../../src/utils/subjectListItemSorting";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const SwiftUI = Platform.OS === "ios" ? require("@expo/ui/swift-ui") : null;
 const DEFAULT_ACTIVE_SRS_STAGES = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const SELECTED_SUBJECT_SORT_SECTIONS = [
+  {
+    id: "sortMode",
+    title: "Sort by",
+    options: SUBJECT_LIST_ITEM_SORT_OPTIONS,
+  },
+];
 
 function setsEqual(a: Set<number>, b: Set<number>): boolean {
   if (a.size !== b.size) return false;
@@ -88,6 +106,9 @@ export default function SubjectListEditorScreen() {
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState<"browse" | "selected">("browse");
   const [showFilters, setShowFilters] = useState(false);
+  const [showSelectedSortModal, setShowSelectedSortModal] = useState(false);
+  const [selectedSubjectSortMode, setSelectedSubjectSortMode] =
+    useState<SubjectListItemSortMode>(DEFAULT_SUBJECT_LIST_ITEM_SORT_MODE);
   const [filters, setFilters] = useState<SearchFilters>(() => {
     const defaults = createDefaultSearchFilters();
     defaults.srsStages = new Set(DEFAULT_ACTIVE_SRS_STAGES);
@@ -107,6 +128,37 @@ export default function SubjectListEditorScreen() {
   const [isCacheMissing, setIsCacheMissing] = useState(false);
   const [isRebuildingCache, setIsRebuildingCache] = useState(false);
   const [cacheRebuildProgress, setCacheRebuildProgress] = useState(0);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    AsyncStorage.getItem(SUBJECT_LIST_ITEM_SORT_STORAGE_KEY)
+      .then((storedMode) => {
+        if (!isMounted || !isSubjectListItemSortMode(storedMode)) {
+          return;
+        }
+        setSelectedSubjectSortMode(storedMode);
+      })
+      .catch((error) => {
+        console.warn("Failed to load subject list sort preference:", error);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const updateSelectedSubjectSortMode = useCallback(
+    (nextMode: SubjectListItemSortMode) => {
+      setSelectedSubjectSortMode(nextMode);
+      AsyncStorage.setItem(SUBJECT_LIST_ITEM_SORT_STORAGE_KEY, nextMode).catch(
+        (error) => {
+          console.warn("Failed to save subject list sort preference:", error);
+        }
+      );
+    },
+    []
+  );
 
   const loadList = useCallback(async () => {
     if (!id) return;
@@ -292,6 +344,19 @@ export default function SubjectListEditorScreen() {
     setSelectedSubjectIds(new Set());
   };
 
+  const selectedSubjectOrderIndex = useMemo(() => {
+    const orderIndex = new Map<number, number>();
+    Array.from(selectedSubjectIds.values()).forEach((subjectId, index) => {
+      orderIndex.set(subjectId, index);
+    });
+    return orderIndex;
+  }, [selectedSubjectIds]);
+
+  const selectedSortValues = useMemo(
+    () => ({ sortMode: selectedSubjectSortMode }),
+    [selectedSubjectSortMode]
+  );
+
   const selectedSubjects = useMemo(() => {
     if (!allSubjects) {
       return [];
@@ -302,16 +367,30 @@ export default function SubjectListEditorScreen() {
     );
     const query = searchQuery.trim();
 
-    const ranked = query
+    const matchingSubjects = query
       ? rankSubjectsByQuery(onlySelected, query).map(({ subject }) => subject)
-      : sortSubjectsByLevelAndType(onlySelected);
+      : onlySelected;
+
+    const ranked = sortSubjectListItems(
+      matchingSubjects,
+      selectedSubjectSortMode,
+      selectedSubjectOrderIndex,
+      subjectSrsStageMap
+    );
 
     if (ranked.length > 250) {
       return ranked.slice(0, 250);
     }
 
     return ranked;
-  }, [allSubjects, searchQuery, selectedSubjectIds]);
+  }, [
+    allSubjects,
+    searchQuery,
+    selectedSubjectIds,
+    selectedSubjectOrderIndex,
+    selectedSubjectSortMode,
+    subjectSrsStageMap,
+  ]);
 
   const allMatchingSelected =
     matchingSubjectIds.length > 0 &&
@@ -862,6 +941,26 @@ export default function SubjectListEditorScreen() {
                 Remove All From List
               </Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                styles.bulkActionButton,
+                { backgroundColor: theme.cardBackground, borderColor: theme.border },
+              ]}
+              onPress={() => setShowSelectedSortModal(true)}
+              activeOpacity={0.8}
+            >
+              <Ionicons
+                name="swap-vertical-outline"
+                size={18}
+                color={theme.textSecondary}
+              />
+              <Text
+                style={[styles.bulkActionText, { color: theme.textSecondary }]}
+                numberOfLines={1}
+              >
+                Sort: {getSubjectListItemSortLabel(selectedSubjectSortMode)}
+              </Text>
+            </TouchableOpacity>
           </View>
         )}
 
@@ -1029,6 +1128,19 @@ export default function SubjectListEditorScreen() {
           onApply={(nextFilters) => {
             setFilters(nextFilters);
             setShowFilters(false);
+          }}
+        />
+        <CommonFilterModal
+          visible={showSelectedSortModal && activeTab === "selected"}
+          title="Sort List"
+          currentValues={selectedSortValues}
+          sections={SELECTED_SUBJECT_SORT_SECTIONS}
+          applyButtonLabel="Apply Sort"
+          onClose={() => setShowSelectedSortModal(false)}
+          onApply={(values) => {
+            if (isSubjectListItemSortMode(values.sortMode)) {
+              updateSelectedSubjectSortMode(values.sortMode);
+            }
           }}
         />
     </View>

--- a/src/components/AddToSubjectListsModal.tsx
+++ b/src/components/AddToSubjectListsModal.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Modal,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -213,6 +214,12 @@ export default function AddToSubjectListsModal({
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>
+        <Pressable
+          accessibilityLabel="Close add to lists modal"
+          accessibilityRole="button"
+          style={styles.backdropPressable}
+          onPress={onClose}
+        />
         <View
           style={[
             styles.container,
@@ -366,8 +373,10 @@ export default function AddToSubjectListsModal({
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    backgroundColor: "rgba(0,0,0,0.5)",
     justifyContent: "flex-end",
+  },
+  backdropPressable: {
+    ...StyleSheet.absoluteFill,
   },
   container: {
     borderTopLeftRadius: 18,

--- a/src/components/CommonFilterModal.tsx
+++ b/src/components/CommonFilterModal.tsx
@@ -30,6 +30,7 @@ interface CommonFilterModalProps {
   currentValues: Record<string, any>;
   sections: FilterSection[];
   title?: string;
+  applyButtonLabel?: string;
 }
 
 export const CommonFilterModal: React.FC<CommonFilterModalProps> = ({
@@ -39,6 +40,7 @@ export const CommonFilterModal: React.FC<CommonFilterModalProps> = ({
   currentValues,
   sections,
   title = "Filters",
+  applyButtonLabel = "Apply Filters",
 }) => {
   const { theme } = useTheme();
   const [pendingValues, setPendingValues] =
@@ -76,7 +78,7 @@ export const CommonFilterModal: React.FC<CommonFilterModalProps> = ({
         }),
       ]).start();
     }
-  }, [visible, currentValues]);
+  }, [visible, currentValues, filterPanelAnimation, backdropOpacity]);
 
   const animateClose = useCallback(() => {
     Animated.parallel([
@@ -93,7 +95,7 @@ export const CommonFilterModal: React.FC<CommonFilterModalProps> = ({
     ]).start(() => {
       onClose();
     });
-  }, [onClose]);
+  }, [onClose, filterPanelAnimation, backdropOpacity]);
 
   const handleApply = useCallback(() => {
     onApply(pendingValues);
@@ -237,7 +239,7 @@ export const CommonFilterModal: React.FC<CommonFilterModalProps> = ({
               activeOpacity={0.7}
             >
               <Text style={[styles.buttonText, { color: "white" }]}>
-                Apply Filters
+                {applyButtonLabel}
               </Text>
             </TouchableOpacity>
           </View>

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -69,6 +69,16 @@ export const PATCH_NOTES: PatchNote[] = [
           label: "Open Review Order Settings",
         },
       },
+      {
+        type: "improvement",
+        title: "Subject List Sorting",
+        description:
+          "Custom subject lists now remember your selected item sort, including newest-added and oldest-added ordering.",
+        link: {
+          route: "/subject-lists",
+          label: "Open Subject Lists",
+        },
+      },
     ],
   },
   {

--- a/src/utils/__tests__/subjectListItemSorting.test.ts
+++ b/src/utils/__tests__/subjectListItemSorting.test.ts
@@ -1,0 +1,76 @@
+import {
+  isSubjectListItemSortMode,
+  sortSubjectListItems,
+} from "../subjectListItemSorting";
+import { Subject } from "../api";
+
+function makeSubject(
+  id: number,
+  level: number,
+  object: string,
+  meaning: string,
+  characters: string | null = null
+): Subject {
+  return {
+    id,
+    object,
+    data: {
+      level,
+      characters,
+      meanings: [{ meaning, primary: true }],
+    },
+  } as unknown as Subject;
+}
+
+describe("subject list item sorting", () => {
+  const radical = makeSubject(1, 3, "radical", "Ground", "一");
+  const kanji = makeSubject(2, 2, "kanji", "Person", "人");
+  const vocabulary = makeSubject(3, 2, "vocabulary", "Apple", "りんご");
+  const orderIndex = new Map([
+    [radical.id, 0],
+    [kanji.id, 1],
+    [vocabulary.id, 2],
+  ]);
+
+  it("sorts newest-added items by reverse selected order", () => {
+    const sorted = sortSubjectListItems(
+      [radical, kanji, vocabulary],
+      "addedDesc",
+      orderIndex,
+      new Map()
+    );
+
+    expect(sorted.map((subject) => subject.id)).toEqual([3, 2, 1]);
+  });
+
+  it("keeps the existing level-low-high order as the default sort", () => {
+    const sorted = sortSubjectListItems(
+      [radical, vocabulary, kanji],
+      "levelAsc",
+      orderIndex,
+      new Map()
+    );
+
+    expect(sorted.map((subject) => subject.id)).toEqual([2, 3, 1]);
+  });
+
+  it("sorts by SRS stage with WaniKani order as the tie-breaker", () => {
+    const sorted = sortSubjectListItems(
+      [radical, kanji, vocabulary],
+      "srsDesc",
+      orderIndex,
+      new Map([
+        [radical.id, 4],
+        [kanji.id, 7],
+        [vocabulary.id, 7],
+      ])
+    );
+
+    expect(sorted.map((subject) => subject.id)).toEqual([2, 3, 1]);
+  });
+
+  it("recognizes only supported cached sort modes", () => {
+    expect(isSubjectListItemSortMode("addedDesc")).toBe(true);
+    expect(isSubjectListItemSortMode("createdDesc")).toBe(false);
+  });
+});

--- a/src/utils/subjectListItemSorting.ts
+++ b/src/utils/subjectListItemSorting.ts
@@ -1,0 +1,167 @@
+import { Subject } from "./api";
+import { getSubjectTypePriority } from "./subjectSearch";
+
+export const SUBJECT_LIST_ITEM_SORT_STORAGE_KEY =
+  "subject_list_editor_selected_sort:v1";
+
+export const SUBJECT_LIST_ITEM_SORT_MODES = [
+  "addedDesc",
+  "addedAsc",
+  "levelAsc",
+  "levelDesc",
+  "type",
+  "meaningAsc",
+  "charactersAsc",
+  "srsDesc",
+  "srsAsc",
+] as const;
+
+export type SubjectListItemSortMode =
+  (typeof SUBJECT_LIST_ITEM_SORT_MODES)[number];
+
+export const DEFAULT_SUBJECT_LIST_ITEM_SORT_MODE: SubjectListItemSortMode =
+  "levelAsc";
+
+export const SUBJECT_LIST_ITEM_SORT_OPTIONS: {
+  id: SubjectListItemSortMode;
+  label: string;
+}[] = [
+  { id: "addedDesc", label: "Newest Added" },
+  { id: "addedAsc", label: "Oldest Added" },
+  { id: "levelAsc", label: "Level Low-High" },
+  { id: "levelDesc", label: "Level High-Low" },
+  { id: "type", label: "Subject Type" },
+  { id: "meaningAsc", label: "Meaning A-Z" },
+  { id: "charactersAsc", label: "Characters A-Z" },
+  { id: "srsDesc", label: "SRS High-Low" },
+  { id: "srsAsc", label: "SRS Low-High" },
+];
+
+export function isSubjectListItemSortMode(
+  value: unknown
+): value is SubjectListItemSortMode {
+  return (
+    typeof value === "string" &&
+    SUBJECT_LIST_ITEM_SORT_MODES.includes(value as SubjectListItemSortMode)
+  );
+}
+
+export function getSubjectListItemSortLabel(
+  mode: SubjectListItemSortMode
+): string {
+  return (
+    SUBJECT_LIST_ITEM_SORT_OPTIONS.find((option) => option.id === mode)?.label ??
+    "Level Low-High"
+  );
+}
+
+function getPrimaryMeaning(subject: Subject): string {
+  return (
+    subject.data.meanings.find((meaning) => meaning.primary)?.meaning ??
+    subject.data.meanings[0]?.meaning ??
+    ""
+  );
+}
+
+function compareByWaniKaniOrder(left: Subject, right: Subject): number {
+  if (left.data.level !== right.data.level) {
+    return left.data.level - right.data.level;
+  }
+
+  const leftType = getSubjectTypePriority(left.object);
+  const rightType = getSubjectTypePriority(right.object);
+  if (leftType !== rightType) {
+    return leftType - rightType;
+  }
+
+  return left.id - right.id;
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+export function sortSubjectListItems(
+  subjects: Subject[],
+  sortMode: SubjectListItemSortMode,
+  selectedSubjectOrderIndex: Map<number, number>,
+  subjectSrsStageMap: Map<number, number>
+): Subject[] {
+  return [...subjects].sort((left, right) => {
+    switch (sortMode) {
+      case "addedDesc": {
+        const leftIndex = selectedSubjectOrderIndex.get(left.id) ?? -1;
+        const rightIndex = selectedSubjectOrderIndex.get(right.id) ?? -1;
+        if (leftIndex !== rightIndex) {
+          return rightIndex - leftIndex;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "addedAsc": {
+        const leftIndex = selectedSubjectOrderIndex.get(left.id) ?? -1;
+        const rightIndex = selectedSubjectOrderIndex.get(right.id) ?? -1;
+        if (leftIndex !== rightIndex) {
+          return leftIndex - rightIndex;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "levelDesc": {
+        if (left.data.level !== right.data.level) {
+          return right.data.level - left.data.level;
+        }
+        const leftType = getSubjectTypePriority(left.object);
+        const rightType = getSubjectTypePriority(right.object);
+        if (leftType !== rightType) {
+          return leftType - rightType;
+        }
+        return left.id - right.id;
+      }
+      case "type": {
+        const leftType = getSubjectTypePriority(left.object);
+        const rightType = getSubjectTypePriority(right.object);
+        if (leftType !== rightType) {
+          return leftType - rightType;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "meaningAsc": {
+        const byMeaning = compareText(
+          getPrimaryMeaning(left),
+          getPrimaryMeaning(right)
+        );
+        if (byMeaning !== 0) {
+          return byMeaning;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "charactersAsc": {
+        const leftCharacters = left.data.characters ?? getPrimaryMeaning(left);
+        const rightCharacters = right.data.characters ?? getPrimaryMeaning(right);
+        const byCharacters = compareText(leftCharacters, rightCharacters);
+        if (byCharacters !== 0) {
+          return byCharacters;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "srsDesc": {
+        const leftStage = subjectSrsStageMap.get(left.id) ?? 0;
+        const rightStage = subjectSrsStageMap.get(right.id) ?? 0;
+        if (leftStage !== rightStage) {
+          return rightStage - leftStage;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "srsAsc": {
+        const leftStage = subjectSrsStageMap.get(left.id) ?? 0;
+        const rightStage = subjectSrsStageMap.get(right.id) ?? 0;
+        if (leftStage !== rightStage) {
+          return leftStage - rightStage;
+        }
+        return compareByWaniKaniOrder(left, right);
+      }
+      case "levelAsc":
+      default:
+        return compareByWaniKaniOrder(left, right);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add persistent sort options for custom subject list items, including newest-added and oldest-added ordering.
- Extract subject list item sorting into a tested utility.
- Preserve custom subject list scroll position when returning from subject details.

