### PR TITLE
[Fix] Cancel Daily Lesson Reminder Reliably

### DIFF
--- a/src/features/settings/useSettingsController.ts
+++ b/src/features/settings/useSettingsController.ts
@@ -1772,6 +1772,32 @@ export function useSettingsController() {
     router.back();
   };
 
+  const getDailyReminderSyncOptions = ({
+    reviewEnabled = dailyReviewReminderEnabled,
+    lessonEnabled = dailyLessonReminderEnabled,
+    lessonMinimum = dailyLessonReminderMinimum,
+    hour = dailyReviewReminderHour,
+    minute = dailyReviewReminderMinute,
+  }: {
+    reviewEnabled?: boolean;
+    lessonEnabled?: boolean;
+    lessonMinimum?: number;
+    hour?: number;
+    minute?: number;
+  } = {}) => ({
+    dailyReviewReminderConfig: {
+      enabled: reviewEnabled,
+      hour,
+      minute,
+    },
+    dailyLessonReminderConfig: {
+      enabled: lessonEnabled,
+      hour,
+      minute,
+      minimumLessons: lessonMinimum,
+    },
+  });
+
   const handleBadgeNotificationChange = async (value: boolean) => {
     setShowBadgeNotifications(value);
 
@@ -1809,7 +1835,7 @@ export function useSettingsController() {
     }
 
     // Keep daily reminder scheduling in sync.
-    await syncDailyReminderNotifications();
+    await syncDailyReminderNotifications(getDailyReminderSyncOptions());
   };
 
   const handleReviewNotificationChange = async (value: boolean) => {
@@ -1825,7 +1851,7 @@ export function useSettingsController() {
       // Keep the old system as fallback for background checks
       await initializeReviewNotifications();
       await scheduleReviewChecks();
-      await syncDailyReminderNotifications();
+      await syncDailyReminderNotifications(getDailyReminderSyncOptions());
     } else {
       // If disabling, cancel all notifications (both old and new systems)
       await cancelReviewNotifications();
@@ -1859,7 +1885,7 @@ export function useSettingsController() {
         }
       }
 
-      await syncDailyReminderNotifications();
+      await syncDailyReminderNotifications(getDailyReminderSyncOptions());
     }
   };
 
@@ -1966,7 +1992,9 @@ export function useSettingsController() {
       }
     }
 
-    await syncDailyReminderNotifications();
+    await syncDailyReminderNotifications(
+      getDailyReminderSyncOptions({ reviewEnabled: value })
+    );
   };
 
   const handleDailyLessonReminderChange = async (value: boolean) => {
@@ -1990,7 +2018,9 @@ export function useSettingsController() {
       }
     }
 
-    await syncDailyReminderNotifications();
+    await syncDailyReminderNotifications(
+      getDailyReminderSyncOptions({ lessonEnabled: value })
+    );
   };
 
   const handleDailyLessonReminderMinimumChange = async (
@@ -2003,7 +2033,9 @@ export function useSettingsController() {
       dailyLessonReminderMinimumStep,
     );
     setDailyLessonReminderMinimum(normalizedMinimum);
-    await syncDailyReminderNotifications();
+    await syncDailyReminderNotifications(
+      getDailyReminderSyncOptions({ lessonMinimum: normalizedMinimum })
+    );
   };
 
   useEffect(() => {
@@ -2027,7 +2059,12 @@ export function useSettingsController() {
     setDailyReviewReminderMinute(reminderMinuteDraft);
     setShowReminderTimeModal(false);
 
-    await syncDailyReminderNotifications();
+    await syncDailyReminderNotifications(
+      getDailyReminderSyncOptions({
+        hour: reminderHourDraft,
+        minute: reminderMinuteDraft,
+      })
+    );
   };
 
   const getCurrentVoiceDisplayName = () => {

--- a/src/utils/__tests__/reviewNotifications.test.ts
+++ b/src/utils/__tests__/reviewNotifications.test.ts
@@ -1,0 +1,167 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import {
+  cancelDailyLessonReminderNotification,
+  syncDailyLessonReminderNotification,
+} from '../reviewNotifications';
+
+jest.mock('expo-notifications', () => ({
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('scheduled-id')),
+  SchedulableTriggerInputTypes: {
+    DAILY: 'daily',
+  },
+}));
+
+jest.mock('expo-task-manager', () => ({
+  defineTask: jest.fn(),
+  isTaskDefined: jest.fn(() => false),
+}));
+
+jest.mock('../platformSupport', () => ({
+  supportsBadgeAndReviewNotifications: jest.fn(() => true),
+}));
+
+jest.mock('../reviewNotificationIntegration', () => ({
+  shouldUseNativeReviewNotificationSystem: jest.fn(() => false),
+}));
+
+jest.mock('../api', () => ({
+  getAssignmentsOptimized: jest.fn(() => Promise.resolve({ data: [] })),
+  getReviewCount: jest.fn(() => Promise.resolve(0)),
+  getStoredApiToken: jest.fn(() => Promise.resolve('api-token')),
+}));
+
+jest.mock('../dailyLessonLimit', () => ({
+  getLessonsStartedToday: jest.fn(() => 0),
+}));
+
+const mockedAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockedNotifications = Notifications as jest.Mocked<typeof Notifications>;
+
+describe('reviewNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAsyncStorage.getItem.mockResolvedValue(null);
+    mockedAsyncStorage.removeItem.mockResolvedValue();
+    mockedNotifications.getAllScheduledNotificationsAsync.mockResolvedValue([]);
+    mockedNotifications.cancelScheduledNotificationAsync.mockResolvedValue();
+    mockedNotifications.scheduleNotificationAsync.mockResolvedValue('scheduled-id');
+  });
+
+  it('cancels stale pending daily lesson reminders even without a stored notification id', async () => {
+    mockedNotifications.getAllScheduledNotificationsAsync.mockResolvedValue([
+      {
+        identifier: 'stale-lesson-reminder',
+        content: {
+          data: {
+            dailyLessonReminder: true,
+          },
+        },
+      },
+      {
+        identifier: 'daily-review-reminder',
+        content: {
+          data: {
+            dailyReminder: true,
+          },
+        },
+      },
+    ] as unknown as Awaited<
+      ReturnType<typeof Notifications.getAllScheduledNotificationsAsync>
+    >);
+
+    await cancelDailyLessonReminderNotification();
+
+    expect(
+      mockedNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mockedNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('stale-lesson-reminder');
+    expect(mockedAsyncStorage.removeItem).toHaveBeenCalledWith(
+      'daily-lesson-reminder-notification-id'
+    );
+  });
+
+  it('clears stale daily lesson reminders when syncing with the setting disabled', async () => {
+    mockedAsyncStorage.getItem.mockImplementation((key) => {
+      if (key === 'wanikani-settings') {
+        return Promise.resolve(
+          JSON.stringify({
+            state: {
+              dailyLessonReminderEnabled: false,
+            },
+          })
+        );
+      }
+
+      return Promise.resolve(null);
+    });
+    mockedNotifications.getAllScheduledNotificationsAsync.mockResolvedValue([
+      {
+        identifier: 'stale-lesson-reminder',
+        content: {
+          data: {
+            dailyLessonReminder: true,
+          },
+        },
+      },
+    ] as unknown as Awaited<
+      ReturnType<typeof Notifications.getAllScheduledNotificationsAsync>
+    >);
+
+    await syncDailyLessonReminderNotification();
+
+    expect(
+      mockedNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('stale-lesson-reminder');
+    expect(mockedNotifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('uses explicit daily lesson reminder overrides instead of stale stored settings', async () => {
+    mockedAsyncStorage.getItem.mockImplementation((key) => {
+      if (key === 'wanikani-settings') {
+        return Promise.resolve(
+          JSON.stringify({
+            state: {
+              dailyLessonReminderEnabled: true,
+              dailyLessonReminderMinimum: 5,
+            },
+          })
+        );
+      }
+
+      return Promise.resolve(null);
+    });
+    mockedNotifications.getAllScheduledNotificationsAsync.mockResolvedValue([
+      {
+        identifier: 'stale-lesson-reminder',
+        content: {
+          data: {
+            dailyLessonReminder: true,
+          },
+        },
+      },
+    ] as unknown as Awaited<
+      ReturnType<typeof Notifications.getAllScheduledNotificationsAsync>
+    >);
+
+    await syncDailyLessonReminderNotification({
+      lessonProgress: {
+        lessonsStartedToday: 0,
+        remainingLessons: 20,
+      },
+      reminderConfig: {
+        enabled: false,
+      },
+    });
+
+    expect(
+      mockedNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('stale-lesson-reminder');
+    expect(mockedNotifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/reviewNotifications.ts
+++ b/src/utils/reviewNotifications.ts
@@ -23,8 +23,17 @@ let lastReviewCountUpdateInFlight: Promise<void> | null = null;
 type UpdateLastReviewCountOptions = {
   reviewCount?: number;
 };
+type DailyReviewReminderConfig = {
+  enabled: boolean;
+  hour: number;
+  minute: number;
+};
+type DailyLessonReminderConfig = DailyReviewReminderConfig & {
+  minimumLessons: number;
+};
 type SyncDailyReviewReminderOptions = {
   reviewCount?: number;
+  reminderConfig?: Partial<DailyReviewReminderConfig>;
 };
 type LessonReminderProgress = {
   lessonsStartedToday: number;
@@ -32,10 +41,13 @@ type LessonReminderProgress = {
 };
 type SyncDailyLessonReminderOptions = {
   lessonProgress?: LessonReminderProgress;
+  reminderConfig?: Partial<DailyLessonReminderConfig>;
 };
 type SyncDailyReminderNotificationsOptions = {
   reviewCount?: number;
   lessonProgress?: LessonReminderProgress;
+  dailyReviewReminderConfig?: Partial<DailyReviewReminderConfig>;
+  dailyLessonReminderConfig?: Partial<DailyLessonReminderConfig>;
 };
 const DAILY_REVIEW_REMINDER_MESSAGES: {
   title: string;
@@ -66,6 +78,68 @@ const DAILY_REVIEW_REMINDER_MESSAGES: {
     body: 'Pending reviews are waiting. Let’s clear some!',
   },
 ];
+
+type ScheduledNotificationRequest = Awaited<
+  ReturnType<typeof Notifications.getAllScheduledNotificationsAsync>
+>[number];
+
+function getScheduledNotificationData(
+  request: ScheduledNotificationRequest
+): Record<string, unknown> | null {
+  const data = request.content?.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  return data as Record<string, unknown>;
+}
+
+async function cancelDailyReminderNotification({
+  storageKey,
+  matchesReminderData,
+}: {
+  storageKey: string;
+  matchesReminderData: (data: Record<string, unknown>) => boolean;
+}): Promise<void> {
+  if (!REVIEW_NOTIFICATION_RUNTIME_SUPPORTED) {
+    return;
+  }
+
+  try {
+    const notificationIdsToCancel = new Set<string>();
+    const scheduledNotificationId = await AsyncStorage.getItem(storageKey);
+    if (scheduledNotificationId) {
+      notificationIdsToCancel.add(scheduledNotificationId);
+    }
+
+    try {
+      const scheduledNotifications =
+        await Notifications.getAllScheduledNotificationsAsync();
+      scheduledNotifications.forEach((request) => {
+        const data = getScheduledNotificationData(request);
+        if (data && matchesReminderData(data)) {
+          notificationIdsToCancel.add(request.identifier);
+        }
+      });
+    } catch {
+      // Fall back to the stored identifier when scheduled notification lookup fails.
+    }
+
+    await Promise.all(
+      Array.from(notificationIdsToCancel).map((notificationId) =>
+        Notifications.cancelScheduledNotificationAsync(notificationId)
+      )
+    );
+  } catch {
+    // Silent failure
+  } finally {
+    try {
+      await AsyncStorage.removeItem(storageKey);
+    } catch {
+      // Silent failure
+    }
+  }
+}
 
 function clampDailyReminderHour(hour: unknown): number {
   if (typeof hour !== 'number') {
@@ -102,11 +176,7 @@ async function isReviewNotificationsEnabled(): Promise<boolean> {
   }
 }
 
-async function getDailyReviewReminderConfig(): Promise<{
-  enabled: boolean;
-  hour: number;
-  minute: number;
-}> {
+async function getDailyReviewReminderConfig(): Promise<DailyReviewReminderConfig> {
   try {
     const settings = await AsyncStorage.getItem('wanikani-settings');
     if (settings) {
@@ -135,12 +205,7 @@ async function getDailyReviewReminderConfig(): Promise<{
   };
 }
 
-async function getDailyLessonReminderConfig(): Promise<{
-  enabled: boolean;
-  minimumLessons: number;
-  hour: number;
-  minute: number;
-}> {
+async function getDailyLessonReminderConfig(): Promise<DailyLessonReminderConfig> {
   try {
     const settings = await AsyncStorage.getItem('wanikani-settings');
     if (settings) {
@@ -240,49 +305,17 @@ async function getReminderMessageForDay(
 }
 
 export async function cancelDailyReviewReminderNotification(): Promise<void> {
-  if (!REVIEW_NOTIFICATION_RUNTIME_SUPPORTED) {
-    return;
-  }
-
-  try {
-    const scheduledNotificationId = await AsyncStorage.getItem(
-      DAILY_REVIEW_REMINDER_NOTIFICATION_ID_KEY
-    );
-    if (scheduledNotificationId) {
-      await Notifications.cancelScheduledNotificationAsync(scheduledNotificationId);
-    }
-  } catch {
-    // Silent failure
-  } finally {
-    try {
-      await AsyncStorage.removeItem(DAILY_REVIEW_REMINDER_NOTIFICATION_ID_KEY);
-    } catch {
-      // Silent failure
-    }
-  }
+  await cancelDailyReminderNotification({
+    storageKey: DAILY_REVIEW_REMINDER_NOTIFICATION_ID_KEY,
+    matchesReminderData: (data) => data.dailyReminder === true,
+  });
 }
 
 export async function cancelDailyLessonReminderNotification(): Promise<void> {
-  if (!REVIEW_NOTIFICATION_RUNTIME_SUPPORTED) {
-    return;
-  }
-
-  try {
-    const scheduledNotificationId = await AsyncStorage.getItem(
-      DAILY_LESSON_REMINDER_NOTIFICATION_ID_KEY
-    );
-    if (scheduledNotificationId) {
-      await Notifications.cancelScheduledNotificationAsync(scheduledNotificationId);
-    }
-  } catch {
-    // Silent failure
-  } finally {
-    try {
-      await AsyncStorage.removeItem(DAILY_LESSON_REMINDER_NOTIFICATION_ID_KEY);
-    } catch {
-      // Silent failure
-    }
-  }
+  await cancelDailyReminderNotification({
+    storageKey: DAILY_LESSON_REMINDER_NOTIFICATION_ID_KEY,
+    matchesReminderData: (data) => data.dailyLessonReminder === true,
+  });
 }
 
 export async function syncDailyReviewReminderNotification(
@@ -295,7 +328,10 @@ export async function syncDailyReviewReminderNotification(
   try {
     await cancelDailyReviewReminderNotification();
 
-    const reminderConfig = await getDailyReviewReminderConfig();
+    const reminderConfig = {
+      ...(await getDailyReviewReminderConfig()),
+      ...options.reminderConfig,
+    };
     if (!reminderConfig.enabled) {
       return;
     }
@@ -423,7 +459,10 @@ export async function syncDailyLessonReminderNotification(
   try {
     await cancelDailyLessonReminderNotification();
 
-    const reminderConfig = await getDailyLessonReminderConfig();
+    const reminderConfig = {
+      ...(await getDailyLessonReminderConfig()),
+      ...options.reminderConfig,
+    };
     if (!reminderConfig.enabled) {
       return;
     }
@@ -476,9 +515,13 @@ export async function syncDailyLessonReminderNotification(
 export async function syncDailyReminderNotifications(
   options: SyncDailyReminderNotificationsOptions = {}
 ): Promise<void> {
-  await syncDailyReviewReminderNotification({ reviewCount: options.reviewCount });
+  await syncDailyReviewReminderNotification({
+    reviewCount: options.reviewCount,
+    reminderConfig: options.dailyReviewReminderConfig,
+  });
   await syncDailyLessonReminderNotification({
     lessonProgress: options.lessonProgress,
+    reminderConfig: options.dailyLessonReminderConfig,
   });
 }
 


### PR DESCRIPTION
## Summary
- Cancel daily reminder notifications by scanning pending Expo notifications for reminder marker data, not only the stored notification ID
- Pass freshly changed reminder settings into notification sync so toggling daily lesson reminders off cannot reschedule from stale storage
- Add regression tests for stale daily lesson reminder cancellation and stale stored settings

