### PR TITLE
[Feature] Study Time Tracking

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,13 +2,13 @@
   "expo": {
     "name": "Kakehashi",
     "slug": "kakehashi",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "kakehashi",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "version": "1.4.6",
+      "version": "1.4.7",
       "supportsTablet": true,
       "bundleIdentifier": "com.portego00.kakehashi",
       "icon": "./ios/Kakehashi.icon",
@@ -39,7 +39,7 @@
       "appleTeamId": "854C975NWV"
     },
     "android": {
-      "version": "1.4.6",
+      "version": "1.4.7",
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon-foreground.png",
         "backgroundImage": "./assets/images/adaptive-icon-background.png",
@@ -217,7 +217,7 @@
         "projectId": "22fd8bf2-11b1-439f-b818-80b2ef36b90b"
       }
     },
-    "runtimeVersion": "1.4.6",
+    "runtimeVersion": "1.4.7",
     "updates": {
       "url": "https://u.expo.dev/22fd8bf2-11b1-439f-b818-80b2ef36b90b",
       "checkAutomatically": "ON_ERROR_RECOVERY"

--- a/app.json
+++ b/app.json
@@ -2,13 +2,13 @@
   "expo": {
     "name": "Kakehashi",
     "slug": "kakehashi",
-    "version": "1.4.7",
+    "version": "1.4.6",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "kakehashi",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "version": "1.4.7",
+      "version": "1.4.6",
       "supportsTablet": true,
       "bundleIdentifier": "com.portego00.kakehashi",
       "icon": "./ios/Kakehashi.icon",
@@ -39,7 +39,7 @@
       "appleTeamId": "854C975NWV"
     },
     "android": {
-      "version": "1.4.7",
+      "version": "1.4.6",
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon-foreground.png",
         "backgroundImage": "./assets/images/adaptive-icon-background.png",
@@ -217,7 +217,7 @@
         "projectId": "22fd8bf2-11b1-439f-b818-80b2ef36b90b"
       }
     },
-    "runtimeVersion": "1.4.7",
+    "runtimeVersion": "1.4.6",
     "updates": {
       "url": "https://u.expo.dev/22fd8bf2-11b1-439f-b818-80b2ef36b90b",
       "checkAutomatically": "ON_ERROR_RECOVERY"

--- a/app/(app)/(tabs)/analytics.tsx
+++ b/app/(app)/(tabs)/analytics.tsx
@@ -24,6 +24,7 @@ import LoadingProgressBar from "../../../src/components/LoadingProgressBar";
 import ReviewHeatmap from "../../../src/components/ReviewHeatmap";
 import ReviewStatsTable from "../../../src/components/ReviewStatsTable";
 import SrsBreakdown from "../../../src/components/SrsBreakdown";
+import StudyTimeCard from "../../../src/components/StudyTimeCard";
 import TodayStudyActivityCard from "../../../src/components/TodayStudyActivityCard";
 import { useDashboardData } from "../../../src/hooks/useDashboardData";
 import {
@@ -280,6 +281,9 @@ export default function AnalyticsTab() {
             assignments={dashboardData.assignments || []}
             reviewStats={dashboardData.reviewStatistics || []}
           />
+
+          {/* Time spent studying today, tracked locally on this device */}
+          <StudyTimeCard />
 
           {/* Progress Section */}
           <View style={styles.progressSection}>

--- a/app/(app)/(tabs)/news/index.tsx
+++ b/app/(app)/(tabs)/news/index.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../../../src/hooks/useActivityTracking";
 import { useRouter } from "expo-router";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -40,6 +41,7 @@ const CAROUSEL_TAP_COOLDOWN_MS = 120;
 type OtherNewsSortMode = "date" | "knownKanji";
 
 export default function NewsScreen() {
+  useActivityTracking("news", { mode: "focus" });
   const [news, setNews] = useState<NhkEasyItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [isCarouselInteracting, setIsCarouselInteracting] = useState(false);

--- a/app/(app)/(tabs)/progress.tsx
+++ b/app/(app)/(tabs)/progress.tsx
@@ -29,6 +29,7 @@ import LoadingProgressBar from "../../../src/components/LoadingProgressBar";
 import ReviewHeatmap from "../../../src/components/ReviewHeatmap";
 import ReviewStatsTable from "../../../src/components/ReviewStatsTable";
 import SrsBreakdown from "../../../src/components/SrsBreakdown";
+import StudyTimeCard from "../../../src/components/StudyTimeCard";
 import {
     BurnedItems,
     CriticalItems,
@@ -538,6 +539,8 @@ export default function ProgressTab() {
                 subjects={dashboardData.subjects}
                 currentLevel={dashboardData.currentLevel}
               />
+
+              <StudyTimeCard />
 
               {/* Progress card */}
               <Animated.View style={[styles.progressCard, { backgroundColor: theme.cardBackground }, animatedCardStyle]}>

--- a/app/(app)/(tabs)/songs.tsx
+++ b/app/(app)/(tabs)/songs.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { FlashList } from "@shopify/flash-list";
 import { Directory, File, Paths } from "expo-file-system";
@@ -51,6 +52,7 @@ interface MusicSection {
 type MusicSource = "spotify" | "apple";
 
 export default function SongsTab() {
+  useActivityTracking("songs", { mode: "focus" });
   const { theme } = useTheme();
   const inputRef = useRef<TextInput>(null);
   const songsPlaybackSource = useSettingsStore(

--- a/app/(app)/anime-transcript-dev-history.tsx
+++ b/app/(app)/anime-transcript-dev-history.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { VideoView, useVideoPlayer } from "expo-video";
@@ -123,6 +124,7 @@ type AnimeTranscriptDevHistoryScreenProps = {
 export default function AnimeTranscriptDevHistoryScreen({
   showBackButton = true,
 }: AnimeTranscriptDevHistoryScreenProps) {
+  useActivityTracking("video", { mode: "focus" });
   const { theme } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/app/(app)/anime-transcript-dev-viewer.tsx
+++ b/app/(app)/anime-transcript-dev-viewer.tsx
@@ -1,4 +1,5 @@
 import { Ionicons, MaterialIcons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import Slider from "@react-native-community/slider";
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
@@ -144,6 +145,7 @@ if (Platform.OS === "ios") {
 }
 
 export default function AnimeTranscriptDevViewerScreen() {
+  useActivityTracking("video", { mode: "focus" });
   const { theme } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/app/(app)/bunpro-lessons.tsx
+++ b/app/(app)/bunpro-lessons.tsx
@@ -1,5 +1,7 @@
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import BunproLessonScreen from "../../src/screens/BunproLessonScreen";
 
 export default function BunproLessonsRoute() {
+  useActivityTracking("bunpro_lessons");
   return <BunproLessonScreen />;
 }

--- a/app/(app)/bunpro-reviews.tsx
+++ b/app/(app)/bunpro-reviews.tsx
@@ -1,5 +1,7 @@
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import BunproReviewScreen from "../../src/screens/BunproReviewScreen";
 
 export default function BunproReviewsRoute() {
+  useActivityTracking("bunpro_reviews");
   return <BunproReviewScreen />;
 }

--- a/app/(app)/context-sentence-practice-session.tsx
+++ b/app/(app)/context-sentence-practice-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -107,6 +108,7 @@ function parseSubjectIds(raw: unknown): number[] {
 }
 
 export default function ContextSentencePracticeSession() {
+  useActivityTracking("context_sentence");
   const { theme } = useTheme();
   const { apiToken, userData } = useAuthStore();
   const { autoSwitchKeyboard, showContextSentenceSpeedControl } =

--- a/app/(app)/crossword-session.tsx
+++ b/app/(app)/crossword-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio, type AudioSound } from "../../src/utils/expoAvCompat";
 import { router, useLocalSearchParams } from "expo-router";
@@ -428,6 +429,7 @@ function containsJapaneseCharacters(value: string): boolean {
 }
 
 export default function CrosswordSessionScreen() {
+  useActivityTracking("crossword");
   const { theme } = useTheme();
   const { apiToken, userData } = useAuthStore();
   const vocabularyAudioVoice = useSettingsStore(

--- a/app/(app)/custom-lesson.tsx
+++ b/app/(app)/custom-lesson.tsx
@@ -1,4 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import React, { useCallback, useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -63,6 +64,7 @@ const isSubjectType = (subject: any, type: string): boolean => {
 };
 
 export default function CustomLessonScreen() {
+  useActivityTracking("custom_lesson");
   const { apiToken } = useAuthStore();
   const { theme } = useTheme();
   const subjectColors = useSubjectColors();

--- a/app/(app)/custom-review.tsx
+++ b/app/(app)/custom-review.tsx
@@ -1,4 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import React, { useCallback, useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -96,6 +97,7 @@ const CUSTOM_REVIEW_SESSION_KEY =
   EXTRA_STUDY_SESSION_STORAGE_KEYS.CUSTOM_REVIEW;
 
 export default function CustomReviewScreen() {
+  useActivityTracking("custom_review");
   const { apiToken } = useAuthStore();
   const { theme } = useTheme();
   const {

--- a/app/(app)/epub-reader.tsx
+++ b/app/(app)/epub-reader.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -102,6 +103,7 @@ const findLookupMatchAtOffset = (
 };
 
 export default function EpubReaderScreen() {
+  useActivityTracking("epub", { mode: "focus" });
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ bookId?: string }>();

--- a/app/(app)/kana-kanji-session.tsx
+++ b/app/(app)/kana-kanji-session.tsx
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
 import {
@@ -112,6 +113,7 @@ const EMPTY_PROGRESS_STATE: KanaKanjiProgressState = {
 const KANA_KANJI_SESSION_KEY = EXTRA_STUDY_SESSION_STORAGE_KEYS.KANA_KANJI;
 
 export default function KanaKanjiSessionScreen() {
+  useActivityTracking("kana_kanji");
   const { theme } = useTheme();
   const { apiToken } = useAuthStore();
   const { isLoading: isAuthLoading } = useSession();

--- a/app/(app)/lessons.tsx
+++ b/app/(app)/lessons.tsx
@@ -15,6 +15,7 @@ import AddToSubjectListsModal from "../../src/components/AddToSubjectListsModal"
 import LessonDetailScreen from "../../src/components/LessonDetailScreen";
 import ReviewQuestionScreen from "../../src/components/ReviewQuestionScreen";
 import { useSession } from "../../src/contexts/AuthContext";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { useDashboardData } from "../../src/hooks/useDashboardData";
 import {
   getPendingProgressAssignmentIds,
@@ -211,6 +212,10 @@ export default function LessonsScreen() {
   const [isFinalBatchComplete, setIsFinalBatchComplete] = useState(false);
   const [showSaveCurrentLessonsModal, setShowSaveCurrentLessonsModal] =
     useState(false);
+
+  // Counts as lesson time from mount until the final completion screen,
+  // including time on screens pushed on top while the flow stays open.
+  useActivityTracking("lessons", { enabled: !isFinalBatchComplete });
   const [lessonSessionCreatedAt, setLessonSessionCreatedAt] = useState<
     string | null
   >(null);

--- a/app/(app)/listening-practice-session.tsx
+++ b/app/(app)/listening-practice-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio, type AudioSound } from "@/src/utils/expoAvCompat";
 import { router, useLocalSearchParams } from "expo-router";
@@ -61,6 +62,7 @@ interface ListeningPracticeSavedSession {
 }
 
 export default function ListeningPracticeSession() {
+  useActivityTracking("listening_practice");
   const { theme } = useTheme();
   const { apiToken, userData } = useAuthStore();
   const { isLoading: isAuthLoading } = useSession();

--- a/app/(app)/meaning-reading-session.tsx
+++ b/app/(app)/meaning-reading-session.tsx
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -214,6 +215,7 @@ async function buildKanjiVocabularyHintMap(
 }
 
 export default function MeaningReadingSessionScreen() {
+  useActivityTracking("meaning_reading");
   const { theme } = useTheme();
   const { apiToken } = useAuthStore();
   const { isLoading: isAuthLoading } = useSession();

--- a/app/(app)/news/[id].tsx
+++ b/app/(app)/news/[id].tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../../src/hooks/useActivityTracking";
 import { Audio, type AudioSound } from "@/src/utils/expoAvCompat";
 import { useFocusEffect } from "@react-navigation/native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -158,6 +159,7 @@ type ContentBlock = {
 };
 
 export default function NewsDetailScreen() {
+  useActivityTracking("news", { mode: "focus" });
   const { id } = useLocalSearchParams<{ id: string }>();
   const [item, setItem] = useState<NhkEasyItem | undefined>(undefined);
   const { theme } = useTheme();

--- a/app/(app)/playlist-detail.tsx
+++ b/app/(app)/playlist-detail.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { FlashList, type FlashListRef } from "@shopify/flash-list";
 import { LinearGradient } from "expo-linear-gradient";
 import { Directory, File, Paths } from "expo-file-system";
@@ -44,6 +45,7 @@ const formatSongCount = (count: number): string =>
   `${count} song${count === 1 ? "" : "s"}`;
 
 export default function PlaylistDetailScreen() {
+  useActivityTracking("songs", { mode: "focus" });
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams();

--- a/app/(app)/recent-lessons-review.tsx
+++ b/app/(app)/recent-lessons-review.tsx
@@ -1,4 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Alert, StyleSheet, Text, View } from "react-native";
 import RecentLessonsResultsScreen from "../../src/components/RecentLessonsResultsScreen";
@@ -27,6 +28,7 @@ interface Question {
 }
 
 export default function RecentLessonsReview() {
+  useActivityTracking("recent_lessons_review");
   const { theme } = useTheme();
   const { apiToken } = useAuthStore();
   const { isLoading: isAuthLoading } = useSession();

--- a/app/(app)/reviews.tsx
+++ b/app/(app)/reviews.tsx
@@ -16,6 +16,7 @@ import ReviewResultsScreen from "../../src/components/ReviewResultsScreen";
 import { useSession } from "../../src/contexts/AuthContext";
 import { useDashboardData } from "../../src/hooks/useDashboardData";
 import useBluetoothAudioKeepAlive from "../../src/hooks/useBluetoothAudioKeepAlive";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import {
   getPendingProgressAssignmentIds,
   getPendingProgressCounts,
@@ -186,6 +187,10 @@ export default function ReviewScreen() {
   const shouldKeepReviewAudioWarm =
     autoplayVocabularyAudio && !isLoading && !isFinished && isFocused;
   useBluetoothAudioKeepAlive(shouldKeepReviewAudioWarm, "Reviews");
+
+  // Counts as review time from mount until the results screen, including time
+  // on screens pushed on top (subject details, search) while the flow is open.
+  useActivityTracking("reviews", { enabled: !isFinished });
 
   const refreshPendingReviewCount = useCallback(async () => {
     try {

--- a/app/(app)/secret/mux-player.tsx
+++ b/app/(app)/secret/mux-player.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../../src/hooks/useActivityTracking";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useVideoPlayer, VideoView } from "expo-video";
 import React, { useCallback, useEffect, useState } from "react";
@@ -29,6 +30,7 @@ import { getAllSubjects } from "../../../src/utils/cache";
 import { useAuthStore } from "../../../src/utils/store";
 
 export default function MuxPlayerScreen() {
+  useActivityTracking("video", { mode: "focus" });
   const { theme } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/app/(app)/secret/youtube-player.tsx
+++ b/app/(app)/secret/youtube-player.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../../src/hooks/useActivityTracking";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback } from "react";
 import {
@@ -13,6 +14,7 @@ import YoutubePlayer from "react-native-youtube-iframe";
 import { useTheme } from "../../../src/utils/theme";
 
 export default function YouTubePlayerScreen() {
+  useActivityTracking("video", { mode: "focus" });
   const { theme } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();

--- a/app/(app)/song-lyrics.tsx
+++ b/app/(app)/song-lyrics.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import * as SwiftUI from "@expo/ui/swift-ui";
 import * as SwiftUIModifiers from "@expo/ui/swift-ui/modifiers";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -300,6 +301,7 @@ function buildGrammarTooltipItem(
 }
 
 export default function SongLyricsScreen() {
+  useActivityTracking("songs", { mode: "focus" });
   const { theme } = useTheme();
   const router = useRouter();
   const { userData } = useAuthStore();

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated, {
+  Easing,
   FadeIn,
   FadeOut,
   LinearTransition,
@@ -46,9 +47,9 @@ import { useTheme } from "../../src/utils/theme";
 const CHART_HEIGHT = 96;
 
 // Drives card expand/collapse and bar resizing when the range changes.
-const cardLayout = LinearTransition.springify()
-  .damping(22)
-  .stiffness(240)
+// Timing-based: settles without spring overshoot.
+const cardLayout = LinearTransition.easing(Easing.inOut(Easing.quad))
+  .duration(240)
   .reduceMotion(ReduceMotion.System);
 
 const sectionEntering = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
@@ -302,20 +303,13 @@ export default function StudyTimeScreen() {
               accessibilityLabel="Color bars by category"
               accessibilityState={{ checked: showChartBreakdown }}
               activeOpacity={0.85}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             >
               <Ionicons
                 name="color-palette-outline"
-                size={13}
+                size={16}
                 color={showChartBreakdown ? "#fff" : theme.textSecondary}
               />
-              <Text
-                style={[
-                  styles.chartToggleLabel,
-                  { color: showChartBreakdown ? "#fff" : theme.textSecondary },
-                ]}
-              >
-                Breakdown
-              </Text>
             </TouchableOpacity>
           </View>
           <View style={styles.chartRow}>
@@ -621,16 +615,11 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   chartToggle: {
-    flexDirection: "row",
+    width: 30,
+    height: 30,
+    borderRadius: 15,
     alignItems: "center",
-    gap: 5,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 12,
-  },
-  chartToggleLabel: {
-    fontSize: 12,
-    fontWeight: "600",
+    justifyContent: "center",
   },
   chartRow: {
     flexDirection: "row",

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -12,7 +12,14 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+  ReduceMotion,
+} from "react-native-reanimated";
 import { GlassButton } from "../../src/components/GlassButton";
+import RollingNumberText from "../../src/components/RollingNumberText";
 import { STUDY_TIME_CATEGORY_META } from "../../src/constants/studyTimeCategories";
 import {
   ACTIVITY_CATEGORIES,
@@ -37,6 +44,15 @@ import {
 import { useTheme } from "../../src/utils/theme";
 
 const CHART_HEIGHT = 96;
+
+// Drives card expand/collapse and bar resizing when the range changes.
+const cardLayout = LinearTransition.springify()
+  .damping(22)
+  .stiffness(240)
+  .reduceMotion(ReduceMotion.System);
+
+const sectionEntering = FadeIn.duration(180).reduceMotion(ReduceMotion.System);
+const sectionExiting = FadeOut.duration(120).reduceMotion(ReduceMotion.System);
 
 type ScreenData = StudyTimeRangeData & {
   syncStatus: StudyTimeSyncStatus;
@@ -75,6 +91,7 @@ export default function StudyTimeScreen() {
   const range = STUDY_TIME_RANGE_IDS[rangeIndex];
   const [data, setData] = useState<ScreenData>(() => readScreenData("today"));
   const [selectedBucketId, setSelectedBucketId] = useState<string | null>(null);
+  const [showChartBreakdown, setShowChartBreakdown] = useState(false);
 
   // Live refresh while focused; all reads are local and in-memory cached.
   useFocusEffect(
@@ -157,56 +174,70 @@ export default function StudyTimeScreen() {
         />
 
         {/* Total for the selected range */}
-        <View style={cardStyle}>
+        <Animated.View style={cardStyle} layout={cardLayout}>
           <Text style={[styles.heroLabel, { color: theme.textSecondary }]}>
             Total study time
           </Text>
-          <Text style={[styles.heroValue, { color: theme.textColor }]}>
-            {formatDurationMs(summary.studyMs)}
-          </Text>
+          <RollingNumberText
+            text={formatDurationMs(summary.studyMs)}
+            style={[styles.heroValue, { color: theme.textColor }]}
+            containerStyle={styles.heroValueContainer}
+          />
           {range !== "today" && (
-            <View style={styles.heroMetaRow}>
+            <Animated.View
+              style={styles.heroMetaRow}
+              entering={sectionEntering}
+              exiting={sectionExiting}
+              layout={cardLayout}
+            >
               <View style={styles.heroMetaItem}>
-                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
-                  {formatDurationMsCoarse(averagePerDayMs)}
-                </Text>
+                <RollingNumberText
+                  text={formatDurationMsCoarse(averagePerDayMs)}
+                  style={[styles.heroMetaValue, { color: theme.textColor }]}
+                />
                 <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
                   avg / day
                 </Text>
               </View>
               <View style={styles.heroMetaItem}>
-                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
-                  {summary.activeDayCount}/{elapsedDays}
-                </Text>
+                <RollingNumberText
+                  text={`${summary.activeDayCount}/${elapsedDays}`}
+                  style={[styles.heroMetaValue, { color: theme.textColor }]}
+                />
                 <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
                   active days
                 </Text>
               </View>
               <View style={styles.heroMetaItem}>
-                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
-                  {formatDurationMsCoarse(
+                <RollingNumberText
+                  text={formatDurationMsCoarse(
                     summary.activeDayCount > 0
                       ? summary.studyMs / summary.activeDayCount
                       : 0
                   )}
-                </Text>
+                  style={[styles.heroMetaValue, { color: theme.textColor }]}
+                />
                 <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
                   avg / active day
                 </Text>
               </View>
-            </View>
+            </Animated.View>
           )}
-        </View>
+        </Animated.View>
 
         {/* Per-category breakdown */}
-        <View style={cardStyle}>
+        <Animated.View style={cardStyle} layout={cardLayout}>
           <Text style={[styles.sectionTitle, { color: theme.textColor }]}>
             Breakdown
           </Text>
           {activeCategories.length === 0 ? (
-            <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+            <Animated.Text
+              entering={sectionEntering}
+              exiting={sectionExiting}
+              style={[styles.emptyText, { color: theme.textSecondary }]}
+            >
               Nothing tracked in this period yet.
-            </Text>
+            </Animated.Text>
           ) : (
             activeCategories.map((category) => {
               const meta = STUDY_TIME_CATEGORY_META[category];
@@ -214,7 +245,13 @@ export default function StudyTimeScreen() {
               const share = summary.studyMs > 0 ? categoryMs / summary.studyMs : 0;
 
               return (
-                <View key={category} style={styles.categoryRow}>
+                <Animated.View
+                  key={category}
+                  style={styles.categoryRow}
+                  entering={sectionEntering}
+                  exiting={sectionExiting}
+                  layout={cardLayout}
+                >
                   <View style={styles.categoryHeader}>
                     <View style={styles.categoryLabelGroup}>
                       <Ionicons name={meta.icon} size={16} color={meta.color} />
@@ -230,7 +267,8 @@ export default function StudyTimeScreen() {
                     </Text>
                   </View>
                   <View style={[styles.categoryTrack, { backgroundColor: trackColor }]}>
-                    <View
+                    <Animated.View
+                      layout={cardLayout}
                       style={[
                         styles.categoryFill,
                         {
@@ -240,17 +278,46 @@ export default function StudyTimeScreen() {
                       ]}
                     />
                   </View>
-                </View>
+                </Animated.View>
               );
             })
           )}
-        </View>
+        </Animated.View>
 
         {/* Range chart */}
-        <View style={cardStyle}>
-          <Text style={[styles.sectionTitle, { color: theme.textColor }]}>
-            {chartTitle}
-          </Text>
+        <Animated.View style={cardStyle} layout={cardLayout}>
+          <View style={styles.chartHeaderRow}>
+            <Text style={[styles.sectionTitle, styles.chartSectionTitle, { color: theme.textColor }]}>
+              {chartTitle}
+            </Text>
+            <TouchableOpacity
+              onPress={() => setShowChartBreakdown((value) => !value)}
+              style={[
+                styles.chartToggle,
+                {
+                  backgroundColor: showChartBreakdown ? theme.primary : trackColor,
+                },
+              ]}
+              accessibilityRole="switch"
+              accessibilityLabel="Color bars by category"
+              accessibilityState={{ checked: showChartBreakdown }}
+              activeOpacity={0.85}
+            >
+              <Ionicons
+                name="color-palette-outline"
+                size={13}
+                color={showChartBreakdown ? "#fff" : theme.textSecondary}
+              />
+              <Text
+                style={[
+                  styles.chartToggleLabel,
+                  { color: showChartBreakdown ? "#fff" : theme.textSecondary },
+                ]}
+              >
+                Breakdown
+              </Text>
+            </TouchableOpacity>
+          </View>
           <View style={styles.chartRow}>
             {series.map((bucket) => {
               const isSelected = bucket.id === selectedBucketId;
@@ -268,20 +335,44 @@ export default function StudyTimeScreen() {
                   }
                 >
                   <View style={styles.chartBarSlot}>
-                    <View
+                    <Animated.View
+                      layout={cardLayout}
                       style={[
                         styles.chartBar,
                         {
                           height: barHeight,
                           backgroundColor:
                             bucket.studyMs > 0
-                              ? isSelected || bucket.isCurrent
-                                ? theme.primary
-                                : `${theme.primary}88`
+                              ? showChartBreakdown
+                                ? "transparent"
+                                : isSelected || bucket.isCurrent
+                                  ? theme.primary
+                                  : `${theme.primary}88`
                               : trackColor,
                         },
                       ]}
-                    />
+                    >
+                      {showChartBreakdown && bucket.studyMs > 0
+                        ? ACTIVITY_CATEGORIES.map((category) => {
+                            const categoryMs = bucket.byCategory[category] ?? 0;
+                            if (categoryMs <= 0) {
+                              return null;
+                            }
+                            return (
+                              <Animated.View
+                                key={category}
+                                entering={sectionEntering}
+                                layout={cardLayout}
+                                style={{
+                                  height: (categoryMs / bucket.studyMs) * barHeight,
+                                  backgroundColor:
+                                    STUDY_TIME_CATEGORY_META[category].color,
+                                }}
+                              />
+                            );
+                          })
+                        : null}
+                    </Animated.View>
                   </View>
                   <Text
                     style={[
@@ -304,10 +395,10 @@ export default function StudyTimeScreen() {
               ? `${selectedBucket.accessibilityLabel} — ${formatDurationMs(selectedBucket.studyMs)}`
               : `Tap a ${chartUnit} bar to see that period's total`}
           </Text>
-        </View>
+        </Animated.View>
 
         {/* App total */}
-        <View style={cardStyle}>
+        <Animated.View style={cardStyle} layout={cardLayout}>
           <View style={styles.appTotalRow}>
             <View style={styles.categoryLabelGroup}>
               <Ionicons name="phone-portrait-outline" size={16} color={theme.textSecondary} />
@@ -315,18 +406,19 @@ export default function StudyTimeScreen() {
                 Total time in app
               </Text>
             </View>
-            <Text style={[styles.categoryValue, { color: theme.textColor }]}>
-              {formatDurationMs(summary.appTotalMs)}
-            </Text>
+            <RollingNumberText
+              text={formatDurationMs(summary.appTotalMs)}
+              style={[styles.categoryValue, { color: theme.textColor }]}
+            />
           </View>
           <Text style={[styles.footnote, { color: theme.textSecondary }]}>
             Includes everything you do in the app, not just study screens. Time
             only counts while the app is in the foreground.
           </Text>
-        </View>
+        </Animated.View>
 
         {/* Sync status — visible so device testers can debug without a console */}
-        <View style={cardStyle}>
+        <Animated.View style={cardStyle} layout={cardLayout}>
           <View style={styles.appTotalRow}>
             <View style={styles.categoryLabelGroup}>
               <Ionicons
@@ -380,7 +472,7 @@ export default function StudyTimeScreen() {
           >
             Project: {getSupabaseHost()}
           </Text>
-        </View>
+        </Animated.View>
       </ScrollView>
     </View>
   );
@@ -455,8 +547,10 @@ const styles = StyleSheet.create({
   heroValue: {
     fontSize: 34,
     fontWeight: "bold",
-    marginTop: 4,
     fontVariant: ["tabular-nums"],
+  },
+  heroValueContainer: {
+    marginTop: 4,
   },
   heroMetaRow: {
     flexDirection: "row",
@@ -515,6 +609,29 @@ const styles = StyleSheet.create({
     height: "100%",
     borderRadius: 4,
   },
+  chartHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 14,
+    gap: 8,
+  },
+  chartSectionTitle: {
+    marginBottom: 0,
+    flexShrink: 1,
+  },
+  chartToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 12,
+  },
+  chartToggleLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
   chartRow: {
     flexDirection: "row",
     alignItems: "flex-end",
@@ -532,6 +649,9 @@ const styles = StyleSheet.create({
   chartBar: {
     borderRadius: 3,
     alignSelf: "stretch",
+    overflow: "hidden",
+    // Stacked category segments render bottom-up.
+    flexDirection: "column-reverse",
   },
   chartDayLabel: {
     fontSize: 10,

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -20,6 +20,7 @@ import {
   type RangeSummary,
 } from "../../src/services/timeTrackingCore";
 import { timeTrackingService } from "../../src/services/timeTrackingService";
+import { maybeSyncStudyTime } from "../../src/services/timeTrackingSyncService";
 import {
   formatDurationMs,
   formatDurationMsCoarse,
@@ -86,6 +87,9 @@ export default function StudyTimeScreen() {
   // Live refresh while focused; all reads are local and in-memory cached.
   useFocusEffect(
     useCallback(() => {
+      // Good moment to push totals to Supabase (throttled internally).
+      maybeSyncStudyTime();
+
       setData(readScreenData(range));
       const timer = setInterval(() => {
         setData(readScreenData(range));

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -2,7 +2,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import SegmentedControl from "@react-native-segmented-control/segmented-control";
 import { router } from "expo-router";
-import { startOfMonth, startOfWeek } from "date-fns";
 import React, { useCallback, useMemo, useState } from "react";
 import {
   Pressable,
@@ -17,10 +16,7 @@ import { GlassButton } from "../../src/components/GlassButton";
 import { STUDY_TIME_CATEGORY_META } from "../../src/constants/studyTimeCategories";
 import {
   ACTIVITY_CATEGORIES,
-  getLocalDateKey,
-  type RangeSummary,
 } from "../../src/services/timeTrackingCore";
-import { timeTrackingService } from "../../src/services/timeTrackingService";
 import {
   getDeviceId,
   getStudyTimeSyncStatus,
@@ -31,20 +27,18 @@ import {
   formatDurationMs,
   formatDurationMsCoarse,
 } from "../../src/utils/durationFormat";
+import {
+  readStudyTimeRangeData,
+  STUDY_TIME_RANGE_IDS,
+  STUDY_TIME_RANGE_LABELS,
+  type StudyTimeRangeData,
+  type StudyTimeRangeId,
+} from "../../src/utils/studyTimeRanges";
 import { useTheme } from "../../src/utils/theme";
 
-type RangeId = "today" | "week" | "month" | "all";
-
-const RANGE_LABELS = ["Today", "Week", "Month", "All"];
-const RANGE_IDS: RangeId[] = ["today", "week", "month", "all"];
-const CHART_DAY_COUNT = 14;
 const CHART_HEIGHT = 96;
 
-type ScreenData = {
-  summary: RangeSummary;
-  startKey: string;
-  elapsedDays: number;
-  series: { dateKey: string; studyMs: number }[];
+type ScreenData = StudyTimeRangeData & {
   syncStatus: StudyTimeSyncStatus;
 };
 
@@ -67,38 +61,9 @@ function formatTimeAgo(timestampMs: number | null): string {
   return `${hours}h ago`;
 }
 
-function parseDateKey(dateKey: string): Date {
-  const [year, month, day] = dateKey.split("-").map(Number);
-  return new Date(year, (month || 1) - 1, day || 1);
-}
-
-function daysBetweenInclusive(startKey: string, endKey: string): number {
-  const oneDayMs = 24 * 60 * 60 * 1000;
-  const diff = Math.round(
-    (parseDateKey(endKey).getTime() - parseDateKey(startKey).getTime()) / oneDayMs
-  );
-  return Math.max(1, diff + 1);
-}
-
-function readScreenData(range: RangeId): ScreenData {
-  const now = new Date();
-  const todayKey = getLocalDateKey(now.getTime());
-
-  let startKey = todayKey;
-  if (range === "week") {
-    startKey = getLocalDateKey(startOfWeek(now, { weekStartsOn: 1 }).getTime());
-  } else if (range === "month") {
-    startKey = getLocalDateKey(startOfMonth(now).getTime());
-  } else if (range === "all") {
-    const { firstDayKey } = timeTrackingService.getAllTimeSummary();
-    startKey = firstDayKey ?? todayKey;
-  }
-
+function readScreenData(range: StudyTimeRangeId): ScreenData {
   return {
-    summary: timeTrackingService.getSummaryBetween(startKey, todayKey),
-    startKey,
-    elapsedDays: daysBetweenInclusive(startKey, todayKey),
-    series: timeTrackingService.getDailyStudySeries(CHART_DAY_COUNT),
+    ...readStudyTimeRangeData(range),
     syncStatus: getStudyTimeSyncStatus(),
   };
 }
@@ -107,9 +72,9 @@ export default function StudyTimeScreen() {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const [rangeIndex, setRangeIndex] = useState(0);
-  const range = RANGE_IDS[rangeIndex];
+  const range = STUDY_TIME_RANGE_IDS[rangeIndex];
   const [data, setData] = useState<ScreenData>(() => readScreenData("today"));
-  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
+  const [selectedBucketId, setSelectedBucketId] = useState<string | null>(null);
 
   // Live refresh while focused; all reads are local and in-memory cached.
   useFocusEffect(
@@ -125,7 +90,7 @@ export default function StudyTimeScreen() {
     }, [range])
   );
 
-  const { summary, elapsedDays, series, syncStatus } = data;
+  const { summary, elapsedDays, series, syncStatus, chartTitle, chartUnit } = data;
 
   const activeCategories = useMemo(
     () =>
@@ -136,7 +101,8 @@ export default function StudyTimeScreen() {
   );
 
   const chartMaxMs = Math.max(1, ...series.map((day) => day.studyMs));
-  const selectedDay = series.find((day) => day.dateKey === selectedDateKey) ?? null;
+  const selectedBucket =
+    series.find((bucket) => bucket.id === selectedBucketId) ?? null;
   const averagePerDayMs = summary.studyMs / elapsedDays;
   const trackColor = theme.isDark ? "#2a2a2a" : "#f0f0f0";
   const cardStyle = [styles.card, { backgroundColor: theme.cardBackground }];
@@ -176,12 +142,13 @@ export default function StudyTimeScreen() {
         showsVerticalScrollIndicator={false}
       >
         <SegmentedControl
-          values={RANGE_LABELS}
+          values={STUDY_TIME_RANGE_LABELS}
           selectedIndex={rangeIndex}
           onChange={(event) => {
             const index = event.nativeEvent.selectedSegmentIndex;
             setRangeIndex(index);
-            setData(readScreenData(RANGE_IDS[index]));
+            setSelectedBucketId(null);
+            setData(readScreenData(STUDY_TIME_RANGE_IDS[index]));
           }}
           style={styles.segmentedControl}
           tintColor={theme.primary}
@@ -279,32 +246,25 @@ export default function StudyTimeScreen() {
           )}
         </View>
 
-        {/* Daily chart */}
+        {/* Range chart */}
         <View style={cardStyle}>
           <Text style={[styles.sectionTitle, { color: theme.textColor }]}>
-            Last {CHART_DAY_COUNT} days
+            {chartTitle}
           </Text>
           <View style={styles.chartRow}>
-            {series.map((day) => {
-              const isToday = day.dateKey === timeTrackingService.getTodayDateKey();
-              const isSelected = day.dateKey === selectedDateKey;
+            {series.map((bucket) => {
+              const isSelected = bucket.id === selectedBucketId;
               const barHeight =
-                day.studyMs > 0
-                  ? Math.max(3, (day.studyMs / chartMaxMs) * CHART_HEIGHT)
+                bucket.studyMs > 0
+                  ? Math.max(3, (bucket.studyMs / chartMaxMs) * CHART_HEIGHT)
                   : 2;
-              const weekdayLetter = new Intl.DateTimeFormat(undefined, {
-                weekday: "short",
-              })
-                .format(parseDateKey(day.dateKey))
-                .slice(0, 1)
-                .toUpperCase();
 
               return (
                 <Pressable
-                  key={day.dateKey}
+                  key={bucket.id}
                   style={styles.chartColumn}
                   onPress={() =>
-                    setSelectedDateKey(isSelected ? null : day.dateKey)
+                    setSelectedBucketId(isSelected ? null : bucket.id)
                   }
                 >
                   <View style={styles.chartBarSlot}>
@@ -314,8 +274,8 @@ export default function StudyTimeScreen() {
                         {
                           height: barHeight,
                           backgroundColor:
-                            day.studyMs > 0
-                              ? isSelected || isToday
+                            bucket.studyMs > 0
+                              ? isSelected || bucket.isCurrent
                                 ? theme.primary
                                 : `${theme.primary}88`
                               : trackColor,
@@ -327,25 +287,22 @@ export default function StudyTimeScreen() {
                     style={[
                       styles.chartDayLabel,
                       {
-                        color: isToday ? theme.textColor : theme.textSecondary,
-                        fontWeight: isToday ? "700" : "400",
+                        color: bucket.isCurrent ? theme.textColor : theme.textSecondary,
+                        fontWeight: bucket.isCurrent ? "700" : "400",
                       },
                     ]}
+                    numberOfLines={1}
                   >
-                    {weekdayLetter}
+                    {bucket.label}
                   </Text>
                 </Pressable>
               );
             })}
           </View>
           <Text style={[styles.chartCaption, { color: theme.textSecondary }]}>
-            {selectedDay
-              ? `${parseDateKey(selectedDay.dateKey).toLocaleDateString(undefined, {
-                  weekday: "short",
-                  month: "short",
-                  day: "numeric",
-                })} — ${formatDurationMs(selectedDay.studyMs)}`
-              : "Tap a bar to see that day's total"}
+            {selectedBucket
+              ? `${selectedBucket.accessibilityLabel} — ${formatDurationMs(selectedBucket.studyMs)}`
+              : `Tap a ${chartUnit} bar to see that period's total`}
           </Text>
         </View>
 

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -417,10 +417,30 @@ export default function StudyTimeScreen() {
           >
             Device ID: {getDeviceId()}
           </Text>
+          <Text
+            style={[styles.footnote, { color: theme.textSecondary }]}
+            selectable
+          >
+            Project: {getSupabaseHost()}
+          </Text>
         </View>
       </ScrollView>
     </View>
   );
+}
+
+// Which Supabase project this build talks to (public client config), so RLS
+// or missing-table errors can be matched against the right dashboard.
+function getSupabaseHost(): string {
+  try {
+    const url = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim();
+    if (!url) {
+      return "not configured";
+    }
+    return new URL(url).host;
+  } catch {
+    return "invalid URL";
+  }
 }
 
 const styles = StyleSheet.create({

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -9,6 +9,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -20,7 +21,12 @@ import {
   type RangeSummary,
 } from "../../src/services/timeTrackingCore";
 import { timeTrackingService } from "../../src/services/timeTrackingService";
-import { maybeSyncStudyTime } from "../../src/services/timeTrackingSyncService";
+import {
+  getDeviceId,
+  getStudyTimeSyncStatus,
+  maybeSyncStudyTime,
+  type StudyTimeSyncStatus,
+} from "../../src/services/timeTrackingSyncService";
 import {
   formatDurationMs,
   formatDurationMsCoarse,
@@ -39,7 +45,27 @@ type ScreenData = {
   startKey: string;
   elapsedDays: number;
   series: { dateKey: string; studyMs: number }[];
+  syncStatus: StudyTimeSyncStatus;
 };
+
+function formatTimeAgo(timestampMs: number | null): string {
+  if (!timestampMs) {
+    return "never";
+  }
+  const seconds = Math.max(0, Math.floor((Date.now() - timestampMs) / 1000));
+  if (seconds < 5) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
 
 function parseDateKey(dateKey: string): Date {
   const [year, month, day] = dateKey.split("-").map(Number);
@@ -73,6 +99,7 @@ function readScreenData(range: RangeId): ScreenData {
     startKey,
     elapsedDays: daysBetweenInclusive(startKey, todayKey),
     series: timeTrackingService.getDailyStudySeries(CHART_DAY_COUNT),
+    syncStatus: getStudyTimeSyncStatus(),
   };
 }
 
@@ -98,7 +125,7 @@ export default function StudyTimeScreen() {
     }, [range])
   );
 
-  const { summary, elapsedDays, series } = data;
+  const { summary, elapsedDays, series, syncStatus } = data;
 
   const activeCategories = useMemo(
     () =>
@@ -340,6 +367,57 @@ export default function StudyTimeScreen() {
             only counts while the app is in the foreground.
           </Text>
         </View>
+
+        {/* Sync status — visible so device testers can debug without a console */}
+        <View style={cardStyle}>
+          <View style={styles.appTotalRow}>
+            <View style={styles.categoryLabelGroup}>
+              <Ionicons
+                name="cloud-upload-outline"
+                size={16}
+                color={theme.textSecondary}
+              />
+              <Text style={[styles.categoryLabel, { color: theme.textColor }]}>
+                Sync
+              </Text>
+            </View>
+            <TouchableOpacity
+              style={[styles.syncNowButton, { backgroundColor: theme.primary }]}
+              onPress={() => {
+                maybeSyncStudyTime({ force: true });
+                setData(readScreenData(range));
+              }}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.syncNowButtonText}>Sync now</Text>
+            </TouchableOpacity>
+          </View>
+          <Text
+            style={[
+              styles.syncDetail,
+              {
+                color:
+                  syncStatus.state === "error"
+                    ? theme.error
+                    : syncStatus.state === "success"
+                      ? "#22C55E"
+                      : theme.textSecondary,
+              },
+            ]}
+          >
+            {syncStatus.detail}
+            {syncStatus.at ? ` (${formatTimeAgo(syncStatus.at)})` : ""}
+          </Text>
+          <Text style={[styles.footnote, { color: theme.textSecondary }]}>
+            Last successful push: {formatTimeAgo(syncStatus.lastSuccessAt)}
+          </Text>
+          <Text
+            style={[styles.footnote, { color: theme.textSecondary }]}
+            selectable
+          >
+            Device ID: {getDeviceId()}
+          </Text>
+        </View>
       </ScrollView>
     </View>
   );
@@ -496,5 +574,20 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 17,
     marginTop: 10,
+  },
+  syncNowButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 14,
+  },
+  syncNowButtonText: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  syncDetail: {
+    fontSize: 13,
+    fontWeight: "500",
+    marginTop: 12,
   },
 });

--- a/app/(app)/study-time.tsx
+++ b/app/(app)/study-time.tsx
@@ -1,0 +1,496 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "@react-navigation/native";
+import SegmentedControl from "@react-native-segmented-control/segmented-control";
+import { router } from "expo-router";
+import { startOfMonth, startOfWeek } from "date-fns";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { GlassButton } from "../../src/components/GlassButton";
+import { STUDY_TIME_CATEGORY_META } from "../../src/constants/studyTimeCategories";
+import {
+  ACTIVITY_CATEGORIES,
+  getLocalDateKey,
+  type RangeSummary,
+} from "../../src/services/timeTrackingCore";
+import { timeTrackingService } from "../../src/services/timeTrackingService";
+import {
+  formatDurationMs,
+  formatDurationMsCoarse,
+} from "../../src/utils/durationFormat";
+import { useTheme } from "../../src/utils/theme";
+
+type RangeId = "today" | "week" | "month" | "all";
+
+const RANGE_LABELS = ["Today", "Week", "Month", "All"];
+const RANGE_IDS: RangeId[] = ["today", "week", "month", "all"];
+const CHART_DAY_COUNT = 14;
+const CHART_HEIGHT = 96;
+
+type ScreenData = {
+  summary: RangeSummary;
+  startKey: string;
+  elapsedDays: number;
+  series: { dateKey: string; studyMs: number }[];
+};
+
+function parseDateKey(dateKey: string): Date {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+}
+
+function daysBetweenInclusive(startKey: string, endKey: string): number {
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  const diff = Math.round(
+    (parseDateKey(endKey).getTime() - parseDateKey(startKey).getTime()) / oneDayMs
+  );
+  return Math.max(1, diff + 1);
+}
+
+function readScreenData(range: RangeId): ScreenData {
+  const now = new Date();
+  const todayKey = getLocalDateKey(now.getTime());
+
+  let startKey = todayKey;
+  if (range === "week") {
+    startKey = getLocalDateKey(startOfWeek(now, { weekStartsOn: 1 }).getTime());
+  } else if (range === "month") {
+    startKey = getLocalDateKey(startOfMonth(now).getTime());
+  } else if (range === "all") {
+    const { firstDayKey } = timeTrackingService.getAllTimeSummary();
+    startKey = firstDayKey ?? todayKey;
+  }
+
+  return {
+    summary: timeTrackingService.getSummaryBetween(startKey, todayKey),
+    startKey,
+    elapsedDays: daysBetweenInclusive(startKey, todayKey),
+    series: timeTrackingService.getDailyStudySeries(CHART_DAY_COUNT),
+  };
+}
+
+export default function StudyTimeScreen() {
+  const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
+  const [rangeIndex, setRangeIndex] = useState(0);
+  const range = RANGE_IDS[rangeIndex];
+  const [data, setData] = useState<ScreenData>(() => readScreenData("today"));
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
+
+  // Live refresh while focused; all reads are local and in-memory cached.
+  useFocusEffect(
+    useCallback(() => {
+      setData(readScreenData(range));
+      const timer = setInterval(() => {
+        setData(readScreenData(range));
+      }, 1000);
+      return () => clearInterval(timer);
+    }, [range])
+  );
+
+  const { summary, elapsedDays, series } = data;
+
+  const activeCategories = useMemo(
+    () =>
+      ACTIVITY_CATEGORIES.filter((category) => summary.byCategory[category] > 0).sort(
+        (a, b) => summary.byCategory[b] - summary.byCategory[a]
+      ),
+    [summary]
+  );
+
+  const chartMaxMs = Math.max(1, ...series.map((day) => day.studyMs));
+  const selectedDay = series.find((day) => day.dateKey === selectedDateKey) ?? null;
+  const averagePerDayMs = summary.studyMs / elapsedDays;
+  const trackColor = theme.isDark ? "#2a2a2a" : "#f0f0f0";
+  const cardStyle = [styles.card, { backgroundColor: theme.cardBackground }];
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: theme.backgroundColor, paddingTop: insets.top + 4 },
+      ]}
+    >
+      <View style={styles.headerRow}>
+        <GlassButton
+          iconName="arrow-back"
+          onPress={() => router.back()}
+          iconColor={theme.textColor}
+          variant="light"
+          style={styles.backButton}
+        />
+        <View style={styles.headerTextGroup}>
+          <Text style={[styles.headerTitle, { color: theme.textColor }]}>
+            Study Time
+          </Text>
+          <Text style={[styles.headerMeta, { color: theme.textSecondary }]}>
+            Tracked on this device while the app is open
+          </Text>
+        </View>
+        <View style={styles.backButtonSpacer} />
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: insets.bottom + 32 },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        <SegmentedControl
+          values={RANGE_LABELS}
+          selectedIndex={rangeIndex}
+          onChange={(event) => {
+            const index = event.nativeEvent.selectedSegmentIndex;
+            setRangeIndex(index);
+            setData(readScreenData(RANGE_IDS[index]));
+          }}
+          style={styles.segmentedControl}
+          tintColor={theme.primary}
+          fontStyle={{ color: theme.textSecondary, fontSize: 13 }}
+          activeFontStyle={{ color: "#fff", fontSize: 13, fontWeight: "600" }}
+        />
+
+        {/* Total for the selected range */}
+        <View style={cardStyle}>
+          <Text style={[styles.heroLabel, { color: theme.textSecondary }]}>
+            Total study time
+          </Text>
+          <Text style={[styles.heroValue, { color: theme.textColor }]}>
+            {formatDurationMs(summary.studyMs)}
+          </Text>
+          {range !== "today" && (
+            <View style={styles.heroMetaRow}>
+              <View style={styles.heroMetaItem}>
+                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
+                  {formatDurationMsCoarse(averagePerDayMs)}
+                </Text>
+                <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
+                  avg / day
+                </Text>
+              </View>
+              <View style={styles.heroMetaItem}>
+                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
+                  {summary.activeDayCount}/{elapsedDays}
+                </Text>
+                <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
+                  active days
+                </Text>
+              </View>
+              <View style={styles.heroMetaItem}>
+                <Text style={[styles.heroMetaValue, { color: theme.textColor }]}>
+                  {formatDurationMsCoarse(
+                    summary.activeDayCount > 0
+                      ? summary.studyMs / summary.activeDayCount
+                      : 0
+                  )}
+                </Text>
+                <Text style={[styles.heroMetaLabel, { color: theme.textSecondary }]}>
+                  avg / active day
+                </Text>
+              </View>
+            </View>
+          )}
+        </View>
+
+        {/* Per-category breakdown */}
+        <View style={cardStyle}>
+          <Text style={[styles.sectionTitle, { color: theme.textColor }]}>
+            Breakdown
+          </Text>
+          {activeCategories.length === 0 ? (
+            <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+              Nothing tracked in this period yet.
+            </Text>
+          ) : (
+            activeCategories.map((category) => {
+              const meta = STUDY_TIME_CATEGORY_META[category];
+              const categoryMs = summary.byCategory[category];
+              const share = summary.studyMs > 0 ? categoryMs / summary.studyMs : 0;
+
+              return (
+                <View key={category} style={styles.categoryRow}>
+                  <View style={styles.categoryHeader}>
+                    <View style={styles.categoryLabelGroup}>
+                      <Ionicons name={meta.icon} size={16} color={meta.color} />
+                      <Text style={[styles.categoryLabel, { color: theme.textColor }]}>
+                        {meta.label}
+                      </Text>
+                    </View>
+                    <Text style={[styles.categoryValue, { color: theme.textColor }]}>
+                      {formatDurationMs(categoryMs)}
+                      <Text style={{ color: theme.textSecondary }}>
+                        {"  "}{Math.round(share * 100)}%
+                      </Text>
+                    </Text>
+                  </View>
+                  <View style={[styles.categoryTrack, { backgroundColor: trackColor }]}>
+                    <View
+                      style={[
+                        styles.categoryFill,
+                        {
+                          backgroundColor: meta.color,
+                          width: `${Math.max(2, Math.round(share * 100))}%`,
+                        },
+                      ]}
+                    />
+                  </View>
+                </View>
+              );
+            })
+          )}
+        </View>
+
+        {/* Daily chart */}
+        <View style={cardStyle}>
+          <Text style={[styles.sectionTitle, { color: theme.textColor }]}>
+            Last {CHART_DAY_COUNT} days
+          </Text>
+          <View style={styles.chartRow}>
+            {series.map((day) => {
+              const isToday = day.dateKey === timeTrackingService.getTodayDateKey();
+              const isSelected = day.dateKey === selectedDateKey;
+              const barHeight =
+                day.studyMs > 0
+                  ? Math.max(3, (day.studyMs / chartMaxMs) * CHART_HEIGHT)
+                  : 2;
+              const weekdayLetter = new Intl.DateTimeFormat(undefined, {
+                weekday: "short",
+              })
+                .format(parseDateKey(day.dateKey))
+                .slice(0, 1)
+                .toUpperCase();
+
+              return (
+                <Pressable
+                  key={day.dateKey}
+                  style={styles.chartColumn}
+                  onPress={() =>
+                    setSelectedDateKey(isSelected ? null : day.dateKey)
+                  }
+                >
+                  <View style={styles.chartBarSlot}>
+                    <View
+                      style={[
+                        styles.chartBar,
+                        {
+                          height: barHeight,
+                          backgroundColor:
+                            day.studyMs > 0
+                              ? isSelected || isToday
+                                ? theme.primary
+                                : `${theme.primary}88`
+                              : trackColor,
+                        },
+                      ]}
+                    />
+                  </View>
+                  <Text
+                    style={[
+                      styles.chartDayLabel,
+                      {
+                        color: isToday ? theme.textColor : theme.textSecondary,
+                        fontWeight: isToday ? "700" : "400",
+                      },
+                    ]}
+                  >
+                    {weekdayLetter}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={[styles.chartCaption, { color: theme.textSecondary }]}>
+            {selectedDay
+              ? `${parseDateKey(selectedDay.dateKey).toLocaleDateString(undefined, {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                })} — ${formatDurationMs(selectedDay.studyMs)}`
+              : "Tap a bar to see that day's total"}
+          </Text>
+        </View>
+
+        {/* App total */}
+        <View style={cardStyle}>
+          <View style={styles.appTotalRow}>
+            <View style={styles.categoryLabelGroup}>
+              <Ionicons name="phone-portrait-outline" size={16} color={theme.textSecondary} />
+              <Text style={[styles.categoryLabel, { color: theme.textColor }]}>
+                Total time in app
+              </Text>
+            </View>
+            <Text style={[styles.categoryValue, { color: theme.textColor }]}>
+              {formatDurationMs(summary.appTotalMs)}
+            </Text>
+          </View>
+          <Text style={[styles.footnote, { color: theme.textSecondary }]}>
+            Includes everything you do in the app, not just study screens. Time
+            only counts while the app is in the foreground.
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  backButton: {
+    marginRight: 12,
+  },
+  backButtonSpacer: {
+    width: 44,
+  },
+  headerTextGroup: {
+    flex: 1,
+    alignItems: "center",
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  headerMeta: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+  },
+  segmentedControl: {
+    height: 36,
+    marginBottom: 16,
+  },
+  card: {
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: "rgba(0,0,0,0.15)",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.8,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  heroLabel: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  heroValue: {
+    fontSize: 34,
+    fontWeight: "bold",
+    marginTop: 4,
+    fontVariant: ["tabular-nums"],
+  },
+  heroMetaRow: {
+    flexDirection: "row",
+    marginTop: 16,
+    gap: 24,
+  },
+  heroMetaItem: {
+    alignItems: "flex-start",
+  },
+  heroMetaValue: {
+    fontSize: 15,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+  },
+  heroMetaLabel: {
+    fontSize: 11,
+    marginTop: 2,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 14,
+  },
+  emptyText: {
+    fontSize: 13,
+  },
+  categoryRow: {
+    marginBottom: 14,
+  },
+  categoryHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 6,
+  },
+  categoryLabelGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  categoryLabel: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  categoryValue: {
+    fontSize: 14,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+  },
+  categoryTrack: {
+    height: 8,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  categoryFill: {
+    height: "100%",
+    borderRadius: 4,
+  },
+  chartRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 4,
+  },
+  chartColumn: {
+    flex: 1,
+    alignItems: "center",
+  },
+  chartBarSlot: {
+    height: CHART_HEIGHT,
+    justifyContent: "flex-end",
+    alignSelf: "stretch",
+  },
+  chartBar: {
+    borderRadius: 3,
+    alignSelf: "stretch",
+  },
+  chartDayLabel: {
+    fontSize: 10,
+    marginTop: 6,
+  },
+  chartCaption: {
+    fontSize: 12,
+    marginTop: 12,
+    textAlign: "center",
+  },
+  appTotalRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  footnote: {
+    fontSize: 12,
+    lineHeight: 17,
+    marginTop: 10,
+  },
+});

--- a/app/(app)/test-session.tsx
+++ b/app/(app)/test-session.tsx
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -432,6 +433,7 @@ const buildRandomTestSession = (
 };
 
 export default function TestSessionScreen() {
+  useActivityTracking("test_session");
   const { theme } = useTheme();
   const { apiToken } = useAuthStore();
   const { isLoading: isAuthLoading } = useSession();

--- a/app/(app)/wordle-session.tsx
+++ b/app/(app)/wordle-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -641,6 +642,7 @@ function WordleSummary({
 }
 
 export default function WordleSessionScreen() {
+  useActivityTracking("wordle");
   const { theme } = useTheme();
   const { apiToken, userData } = useAuthStore();
   const userLevel = userData?.level ?? 60;

--- a/app/(app)/writing-practice-freehand-session.tsx
+++ b/app/(app)/writing-practice-freehand-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
@@ -87,6 +88,7 @@ const WRITING_PRACTICE_SESSION_KEY =
   EXTRA_STUDY_SESSION_STORAGE_KEYS.WRITING_PRACTICE;
 
 export default function WritingPracticeSessionScreen() {
+  useActivityTracking("writing_freehand");
   const { theme } = useTheme();
   const subjectColors = useSubjectColors();
   const insets = useSafeAreaInsets();

--- a/app/(app)/writing-practice-session.tsx
+++ b/app/(app)/writing-practice-session.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useActivityTracking } from "../../src/hooks/useActivityTracking";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
@@ -79,6 +80,7 @@ const WRITING_PRACTICE_SESSION_KEY =
   EXTRA_STUDY_SESSION_STORAGE_KEYS.WRITING_PRACTICE;
 
 export default function WritingPracticeSessionScreen() {
+  useActivityTracking("writing_practice");
   const { theme } = useTheme();
   const subjectColors = useSubjectColors();
   const { apiToken } = useAuthStore();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -28,6 +28,8 @@ import { analyticsService } from "../src/services/analyticsService";
 import { featureFlagsService } from "../src/services/featureFlagsService";
 import { syncPendingProgress } from "../src/services/offlineStudyProgressService";
 import { queueOfflineVocabularyAudioDownloads } from "../src/services/offlineVocabularyAudioService";
+import { timeTrackingService } from "../src/services/timeTrackingService";
+import { initializeTimeTrackingSync } from "../src/services/timeTrackingSyncService";
 import { getAllSubjectsFromAPI, getUserData } from "../src/utils/api";
 import {
   initializeBadgeNotifications,
@@ -287,6 +289,12 @@ function RootLayoutContentInner() {
   // Initialize global error handlers
   useEffect(() => {
     errorService.initializeGlobalHandlers();
+  }, []);
+
+  // Start the app/study time tracker (MMKV ledger + AppState heartbeat)
+  useEffect(() => {
+    timeTrackingService.initialize();
+    initializeTimeTrackingSync();
   }, []);
 
   // Set user info for error attribution

--- a/ios/wanikani/Info.plist
+++ b/ios/wanikani/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.6</string>
+    <string>1.4.7</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/wanikani/Info.plist
+++ b/ios/wanikani/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.4.7</string>
+    <string>1.4.6</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/wanikani/Supporting/Expo.plist
+++ b/ios/wanikani/Supporting/Expo.plist
@@ -9,7 +9,7 @@
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.4.6</string>
+    <string>1.4.7</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/22fd8bf2-11b1-439f-b818-80b2ef36b90b</string>
   </dict>

--- a/ios/wanikani/Supporting/Expo.plist
+++ b/ios/wanikani/Supporting/Expo.plist
@@ -9,7 +9,7 @@
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.4.7</string>
+    <string>1.4.6</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/22fd8bf2-11b1-439f-b818-80b2ef36b90b</string>
   </dict>

--- a/src/components/HomeDashboardWidget.tsx
+++ b/src/components/HomeDashboardWidget.tsx
@@ -24,6 +24,7 @@ import SrsBreakdown, {
   type SrsBreakdownGroupStagesScope,
   type SrsBreakdownViewMode,
 } from "./SrsBreakdown";
+import StudyTimeCard from "./StudyTimeCard";
 import TodayStudyActivityCard from "./TodayStudyActivityCard";
 import {
   BurnedItems,
@@ -611,6 +612,8 @@ export default function HomeDashboardWidget({
           style={style}
         />
       );
+    case "studyTime":
+      return <StudyTimeCard interactive={interactive} style={style} />;
     case "srsBreakdown":
       return (
         <View style={[styles.srsSection, style]}>

--- a/src/components/RollingNumberText.tsx
+++ b/src/components/RollingNumberText.tsx
@@ -1,0 +1,166 @@
+import React, { memo, useEffect } from "react";
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native";
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
+
+/**
+ * Text whose digits roll vertically (iOS-style) when the value changes.
+ * Non-digit characters (units like "h"/"m"/"s", separators) render as plain
+ * text and crossfade when they appear or disappear.
+ *
+ * Implementation: each digit is a clipped column of 0-9 translated with a
+ * spring. Characters are keyed by their position from the RIGHT so trailing
+ * digits keep their identity while the number grows (e.g. "9m 59s" ->
+ * "10m 00s" rolls instead of remounting).
+ *
+ * Pass only text styles in `style` (fontSize, color, weight...). Margins and
+ * layout belong in `containerStyle`.
+ */
+
+const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+const HEIGHT_PER_FONT_SIZE = 1.25;
+
+const DIGIT_SPRING = {
+  damping: 20,
+  stiffness: 220,
+  mass: 0.9,
+  reduceMotion: ReduceMotion.System,
+};
+
+const charLayout = LinearTransition.springify()
+  .damping(22)
+  .stiffness(260)
+  .reduceMotion(ReduceMotion.System);
+
+const charEntering = FadeIn.duration(160).reduceMotion(ReduceMotion.System);
+const charExiting = FadeOut.duration(110).reduceMotion(ReduceMotion.System);
+
+type RollingDigitProps = {
+  digit: number;
+  height: number;
+  textStyle: StyleProp<TextStyle>;
+};
+
+const RollingDigit = memo(function RollingDigit({
+  digit,
+  height,
+  textStyle,
+}: RollingDigitProps) {
+  const translateY = useSharedValue(-digit * height);
+
+  useEffect(() => {
+    translateY.value = withSpring(-digit * height, DIGIT_SPRING);
+  }, [digit, height, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <View style={{ height, overflow: "hidden" }}>
+      <Animated.View style={animatedStyle}>
+        {DIGITS.map((value) => (
+          <Text
+            key={value}
+            style={[
+              textStyle,
+              {
+                height,
+                lineHeight: height,
+                includeFontPadding: false,
+                textAlign: "center",
+              },
+            ]}
+          >
+            {value}
+          </Text>
+        ))}
+      </Animated.View>
+    </View>
+  );
+});
+
+type RollingNumberTextProps = {
+  text: string;
+  /** Text styles only (fontSize, color, fontWeight, fontVariant...). */
+  style?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+};
+
+export default function RollingNumberText({
+  text,
+  style,
+  containerStyle,
+}: RollingNumberTextProps) {
+  const flattened = StyleSheet.flatten(style) ?? {};
+  const fontSize = typeof flattened.fontSize === "number" ? flattened.fontSize : 14;
+  const height = Math.round(fontSize * HEIGHT_PER_FONT_SIZE);
+  const chars = text.split("");
+
+  return (
+    <Animated.View
+      style={[styles.row, containerStyle]}
+      layout={charLayout}
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={text}
+    >
+      {chars.map((char, index) => {
+        const positionFromRight = chars.length - 1 - index;
+        const isDigit = char >= "0" && char <= "9";
+
+        if (isDigit) {
+          return (
+            <Animated.View
+              key={`digit-${positionFromRight}`}
+              entering={charEntering}
+              exiting={charExiting}
+              layout={charLayout}
+            >
+              <RollingDigit digit={Number(char)} height={height} textStyle={style} />
+            </Animated.View>
+          );
+        }
+
+        return (
+          <Animated.View
+            key={`char-${positionFromRight}-${char}`}
+            entering={charEntering}
+            exiting={charExiting}
+            layout={charLayout}
+          >
+            <Text
+              style={[
+                style,
+                { height, lineHeight: height, includeFontPadding: false },
+              ]}
+            >
+              {char}
+            </Text>
+          </Animated.View>
+        );
+      })}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+});

--- a/src/components/RollingNumberText.tsx
+++ b/src/components/RollingNumberText.tsx
@@ -8,13 +8,14 @@ import {
   ViewStyle,
 } from "react-native";
 import Animated, {
+  Easing,
   FadeIn,
   FadeOut,
   LinearTransition,
   ReduceMotion,
   useAnimatedStyle,
   useSharedValue,
-  withSpring,
+  withTiming,
 } from "react-native-reanimated";
 
 /**
@@ -34,16 +35,15 @@ import Animated, {
 const DIGITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 const HEIGHT_PER_FONT_SIZE = 1.25;
 
-const DIGIT_SPRING = {
-  damping: 20,
-  stiffness: 220,
-  mass: 0.9,
+// Ease-out timing: settles cleanly without overshooting past the digit.
+const DIGIT_TIMING = {
+  duration: 280,
+  easing: Easing.out(Easing.cubic),
   reduceMotion: ReduceMotion.System,
 };
 
-const charLayout = LinearTransition.springify()
-  .damping(22)
-  .stiffness(260)
+const charLayout = LinearTransition.easing(Easing.inOut(Easing.quad))
+  .duration(200)
   .reduceMotion(ReduceMotion.System);
 
 const charEntering = FadeIn.duration(160).reduceMotion(ReduceMotion.System);
@@ -63,7 +63,7 @@ const RollingDigit = memo(function RollingDigit({
   const translateY = useSharedValue(-digit * height);
 
   useEffect(() => {
-    translateY.value = withSpring(-digit * height, DIGIT_SPRING);
+    translateY.value = withTiming(-digit * height, DIGIT_TIMING);
   }, [digit, height, translateY]);
 
   const animatedStyle = useAnimatedStyle(() => ({

--- a/src/components/StudyTimeCard.tsx
+++ b/src/components/StudyTimeCard.tsx
@@ -1,0 +1,172 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "@react-navigation/native";
+import { router } from "expo-router";
+import React, { useCallback, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { STUDY_TIME_CATEGORY_META } from "../constants/studyTimeCategories";
+import {
+  ACTIVITY_CATEGORIES,
+  addRecordToSummary,
+  emptyRangeSummary,
+  type RangeSummary,
+} from "../services/timeTrackingCore";
+import { timeTrackingService } from "../services/timeTrackingService";
+import { formatDurationMs } from "../utils/durationFormat";
+import { useTheme } from "../utils/theme";
+
+function readTodaySummary(): RangeSummary {
+  const summary = emptyRangeSummary();
+  addRecordToSummary(summary, timeTrackingService.getLiveToday());
+  return summary;
+}
+
+export default function StudyTimeCard() {
+  const { theme } = useTheme();
+  const [today, setToday] = useState<RangeSummary>(readTodaySummary);
+
+  // Live clock: refresh once a second while the tab is focused. Reads are
+  // in-memory (MMKV cache) and the tracker never writes on reads.
+  useFocusEffect(
+    useCallback(() => {
+      setToday(readTodaySummary());
+      const timer = setInterval(() => {
+        setToday(readTodaySummary());
+      }, 1000);
+      return () => clearInterval(timer);
+    }, [])
+  );
+
+  const activeCategories = ACTIVITY_CATEGORIES.filter(
+    (category) => today.byCategory[category] > 0
+  ).sort((a, b) => today.byCategory[b] - today.byCategory[a]);
+
+  const trackColor = theme.isDark ? "#2a2a2a" : "#f0f0f0";
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, { backgroundColor: theme.cardBackground }]}
+      onPress={() => router.push("/study-time")}
+      activeOpacity={0.85}
+    >
+      <View style={styles.headerRow}>
+        <View style={styles.titleGroup}>
+          <Ionicons name="time-outline" size={18} color={theme.textColor} />
+          <Text style={[styles.title, { color: theme.textColor }]}>Study Time</Text>
+        </View>
+        <View style={styles.todayGroup}>
+          <Text style={[styles.todayValue, { color: theme.textColor }]}>
+            {formatDurationMs(today.studyMs)}
+          </Text>
+          <Ionicons name="chevron-forward" size={16} color={theme.textSecondary} />
+        </View>
+      </View>
+
+      {today.studyMs > 0 ? (
+        <>
+          <View style={[styles.stackedBar, { backgroundColor: trackColor }]}>
+            {activeCategories.map((category) => (
+              <View
+                key={category}
+                style={{
+                  flex: today.byCategory[category],
+                  backgroundColor: STUDY_TIME_CATEGORY_META[category].color,
+                }}
+              />
+            ))}
+          </View>
+          <View style={styles.chipsRow}>
+            {activeCategories.map((category) => (
+              <View key={category} style={styles.chip}>
+                <View
+                  style={[
+                    styles.chipDot,
+                    { backgroundColor: STUDY_TIME_CATEGORY_META[category].color },
+                  ]}
+                />
+                <Text style={[styles.chipLabel, { color: theme.textSecondary }]}>
+                  {STUDY_TIME_CATEGORY_META[category].label}{" "}
+                  {formatDurationMs(today.byCategory[category])}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </>
+      ) : (
+        <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+          No study time yet today. Time spent on reviews, lessons, extra study,
+          news, songs, reading, and videos shows up here.
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    padding: 20,
+    marginHorizontal: 4,
+    marginBottom: 16,
+    shadowColor: "rgba(0,0,0,0.15)",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.8,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  titleGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  todayGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  todayValue: {
+    fontSize: 16,
+    fontWeight: "bold",
+    fontVariant: ["tabular-nums"],
+  },
+  stackedBar: {
+    flexDirection: "row",
+    height: 10,
+    borderRadius: 5,
+    overflow: "hidden",
+    marginTop: 14,
+  },
+  chipsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    marginTop: 12,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+  },
+  chipDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  chipLabel: {
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  emptyText: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 10,
+  },
+});

--- a/src/components/StudyTimeCard.tsx
+++ b/src/components/StudyTimeCard.tsx
@@ -1,74 +1,184 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
+import SegmentedControl from "@react-native-segmented-control/segmented-control";
 import { router } from "expo-router";
 import React, { useCallback, useState } from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from "react-native";
 import { STUDY_TIME_CATEGORY_META } from "../constants/studyTimeCategories";
 import {
   ACTIVITY_CATEGORIES,
-  addRecordToSummary,
-  emptyRangeSummary,
-  type RangeSummary,
 } from "../services/timeTrackingCore";
-import { timeTrackingService } from "../services/timeTrackingService";
 import { formatDurationMs } from "../utils/durationFormat";
+import { withAlpha } from "../utils/subjectColors";
+import {
+  readStudyTimeRangeData,
+  STUDY_TIME_RANGE_IDS,
+  STUDY_TIME_RANGE_LABELS,
+  type StudyTimeRangeData,
+} from "../utils/studyTimeRanges";
 import { useTheme } from "../utils/theme";
 
-function readTodaySummary(): RangeSummary {
-  const summary = emptyRangeSummary();
-  addRecordToSummary(summary, timeTrackingService.getLiveToday());
-  return summary;
-}
+const CARD_CHART_HEIGHT = 58;
 
-export default function StudyTimeCard() {
+type StudyTimeCardProps = {
+  interactive?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export default function StudyTimeCard({
+  interactive = true,
+  style,
+}: StudyTimeCardProps) {
   const { theme } = useTheme();
-  const [today, setToday] = useState<RangeSummary>(readTodaySummary);
+  const [rangeIndex, setRangeIndex] = useState(0);
+  const range = STUDY_TIME_RANGE_IDS[rangeIndex];
+  const [data, setData] = useState<StudyTimeRangeData>(() =>
+    readStudyTimeRangeData("today"),
+  );
 
   // Live clock: refresh once a second while the tab is focused. Reads are
   // in-memory (MMKV cache) and the tracker never writes on reads.
   useFocusEffect(
     useCallback(() => {
-      setToday(readTodaySummary());
+      setData(readStudyTimeRangeData(range));
       const timer = setInterval(() => {
-        setToday(readTodaySummary());
+        setData(readStudyTimeRangeData(range));
       }, 1000);
       return () => clearInterval(timer);
-    }, [])
+    }, [range])
   );
 
+  const { summary, series, chartTitle } = data;
   const activeCategories = ACTIVITY_CATEGORIES.filter(
-    (category) => today.byCategory[category] > 0
-  ).sort((a, b) => today.byCategory[b] - today.byCategory[a]);
+    (category) => summary.byCategory[category] > 0
+  ).sort((a, b) => summary.byCategory[b] - summary.byCategory[a]);
 
   const trackColor = theme.isDark ? "#2a2a2a" : "#f0f0f0";
+  const chartMaxMs = Math.max(1, ...series.map((bucket) => bucket.studyMs));
 
   return (
-    <TouchableOpacity
-      style={[styles.card, { backgroundColor: theme.cardBackground }]}
-      onPress={() => router.push("/study-time")}
-      activeOpacity={0.85}
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: theme.cardBackground,
+          borderColor: theme.border,
+        },
+        style,
+      ]}
     >
       <View style={styles.headerRow}>
-        <View style={styles.titleGroup}>
-          <Ionicons name="time-outline" size={18} color={theme.textColor} />
-          <Text style={[styles.title, { color: theme.textColor }]}>Study Time</Text>
+        <View style={styles.headerLeft}>
+          <View
+            style={[
+              styles.iconBadge,
+              { backgroundColor: withAlpha(theme.primary, theme.isDark ? 0.34 : 0.18) },
+            ]}
+          >
+            <Ionicons name="time-outline" size={18} color={theme.primary} />
+          </View>
+          <Text style={[styles.title, { color: theme.textColor }]}>
+            Study Time
+          </Text>
         </View>
-        <View style={styles.todayGroup}>
+        <TouchableOpacity
+          style={styles.todayGroup}
+          onPress={() => {
+            if (interactive) {
+              router.push("/study-time" as any);
+            }
+          }}
+          activeOpacity={interactive ? 0.85 : 1}
+          disabled={!interactive}
+        >
           <Text style={[styles.todayValue, { color: theme.textColor }]}>
-            {formatDurationMs(today.studyMs)}
+            {formatDurationMs(summary.studyMs)}
           </Text>
           <Ionicons name="chevron-forward" size={16} color={theme.textSecondary} />
-        </View>
+        </TouchableOpacity>
       </View>
 
-      {today.studyMs > 0 ? (
+      <SegmentedControl
+        values={STUDY_TIME_RANGE_LABELS}
+        selectedIndex={rangeIndex}
+        onChange={(event) => {
+          const index = event.nativeEvent.selectedSegmentIndex;
+          setRangeIndex(index);
+          setData(readStudyTimeRangeData(STUDY_TIME_RANGE_IDS[index]));
+        }}
+        style={styles.segmentedControl}
+        tintColor={theme.primary}
+        fontStyle={{ color: theme.textSecondary, fontSize: 12 }}
+        activeFontStyle={{ color: "#fff", fontSize: 12, fontWeight: "600" }}
+        enabled={interactive}
+      />
+
+      <View style={styles.chartHeaderRow}>
+        <Text style={[styles.chartTitle, { color: theme.textSecondary }]}>
+          {chartTitle}
+        </Text>
+      </View>
+      <View style={styles.chartRow}>
+        {series.map((bucket, index) => {
+          const barHeight =
+            bucket.studyMs > 0
+              ? Math.max(3, (bucket.studyMs / chartMaxMs) * CARD_CHART_HEIGHT)
+              : 2;
+          const shouldShowLabel =
+            bucket.isCurrent || index === 0 || index === series.length - 1;
+
+          return (
+            <View key={bucket.id} style={styles.chartColumn}>
+              <View style={styles.chartBarSlot}>
+                <View
+                  style={[
+                    styles.chartBar,
+                    {
+                      height: barHeight,
+                      backgroundColor:
+                        bucket.studyMs > 0
+                          ? bucket.isCurrent
+                            ? theme.primary
+                            : `${theme.primary}88`
+                          : trackColor,
+                    },
+                  ]}
+                />
+              </View>
+              <Text
+                style={[
+                  styles.chartLabel,
+                  {
+                    color: bucket.isCurrent
+                      ? theme.textColor
+                      : theme.textSecondary,
+                    fontWeight: bucket.isCurrent ? "700" : "500",
+                  },
+                ]}
+                numberOfLines={1}
+              >
+                {shouldShowLabel ? bucket.label : ""}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+
+      {summary.studyMs > 0 ? (
         <>
           <View style={[styles.stackedBar, { backgroundColor: trackColor }]}>
             {activeCategories.map((category) => (
               <View
                 key={category}
                 style={{
-                  flex: today.byCategory[category],
+                  flex: summary.byCategory[category],
                   backgroundColor: STUDY_TIME_CATEGORY_META[category].color,
                 }}
               />
@@ -85,7 +195,7 @@ export default function StudyTimeCard() {
                 />
                 <Text style={[styles.chipLabel, { color: theme.textSecondary }]}>
                   {STUDY_TIME_CATEGORY_META[category].label}{" "}
-                  {formatDurationMs(today.byCategory[category])}
+                  {formatDurationMs(summary.byCategory[category])}
                 </Text>
               </View>
             ))}
@@ -93,49 +203,92 @@ export default function StudyTimeCard() {
         </>
       ) : (
         <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
-          No study time yet today. Time spent on reviews, lessons, extra study,
+          No study time in this range yet. Time spent on reviews, lessons, extra study,
           news, songs, reading, and videos shows up here.
         </Text>
       )}
-    </TouchableOpacity>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
     borderRadius: 16,
-    padding: 20,
-    marginHorizontal: 4,
+    borderWidth: 1,
     marginBottom: 16,
-    shadowColor: "rgba(0,0,0,0.15)",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.8,
-    shadowRadius: 8,
-    elevation: 4,
+    padding: 16,
+    overflow: "hidden",
   },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    gap: 12,
   },
-  titleGroup: {
+  headerLeft: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: 12,
+    flex: 1,
+    minWidth: 0,
+  },
+  iconBadge: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
   },
   title: {
-    fontSize: 16,
-    fontWeight: "600",
+    fontSize: 18,
+    fontWeight: "700",
   },
   todayGroup: {
     flexDirection: "row",
     alignItems: "center",
     gap: 4,
+    flexShrink: 0,
   },
   todayValue: {
     fontSize: 16,
     fontWeight: "bold",
     fontVariant: ["tabular-nums"],
+  },
+  segmentedControl: {
+    height: 32,
+    marginTop: 14,
+  },
+  chartHeaderRow: {
+    marginTop: 14,
+  },
+  chartTitle: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  chartRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 4,
+    marginTop: 8,
+  },
+  chartColumn: {
+    flex: 1,
+    alignItems: "center",
+    minWidth: 0,
+  },
+  chartBarSlot: {
+    height: CARD_CHART_HEIGHT,
+    justifyContent: "flex-end",
+    alignSelf: "stretch",
+  },
+  chartBar: {
+    borderRadius: 3,
+    alignSelf: "stretch",
+  },
+  chartLabel: {
+    marginTop: 5,
+    minHeight: 12,
+    fontSize: 9,
   },
   stackedBar: {
     flexDirection: "row",

--- a/src/constants/studyTimeCategories.ts
+++ b/src/constants/studyTimeCategories.ts
@@ -1,0 +1,20 @@
+import type { Ionicons } from "@expo/vector-icons";
+import type { ActivityCategory } from "../services/timeTrackingCore";
+
+type IoniconName = keyof typeof Ionicons.glyphMap;
+
+export type StudyTimeCategoryMeta = {
+  label: string;
+  icon: IoniconName;
+  color: string;
+};
+
+export const STUDY_TIME_CATEGORY_META: Record<ActivityCategory, StudyTimeCategoryMeta> = {
+  reviews: { label: "Reviews", icon: "albums-outline", color: "#00AAFF" },
+  lessons: { label: "Lessons", icon: "school-outline", color: "#FF00AA" },
+  extra_study: { label: "Extra Study", icon: "barbell-outline", color: "#AA00FF" },
+  news: { label: "NHK News", icon: "newspaper-outline", color: "#FF7043" },
+  songs: { label: "Songs", icon: "musical-notes-outline", color: "#1DB954" },
+  epub: { label: "Reading", icon: "book-outline", color: "#FFB300" },
+  video: { label: "Video", icon: "play-circle-outline", color: "#E53935" },
+};

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,22 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.78",
+    date: "2026-06-10",
+    changes: [
+      {
+        type: "feature",
+        title: "Study Time Tracking",
+        description:
+          "The app now tracks how long you spend on reviews, lessons, extra study, NHK news, songs, reading, and videos each day, stored privately on your device. Check daily, weekly, and monthly totals with averages from the new Study Time card in Analytics.",
+        link: {
+          route: "/study-time",
+          label: "Open Study Time",
+        },
+      },
+    ],
+  },
+  {
     version: "1.2.77",
     date: "2026-06-09",
     changes: [

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -57,13 +57,13 @@ export const getCurrentPatchNotesVersion = (): string => {
 export const PATCH_NOTES: PatchNote[] = [
   {
     version: "1.2.78",
-    date: "2026-06-10",
+    date: "2026-06-11",
     changes: [
       {
         type: "feature",
         title: "Study Time Tracking",
         description:
-          "The app now tracks how long you spend on reviews, lessons, extra study, NHK news, songs, reading, and videos each day, stored privately on your device. Check daily, weekly, and monthly totals with averages from the new Study Time card in Analytics.",
+          "The app now saves how long you spend on reviews, lessons, extra study, NHK news, songs, reading, and videos each day. Check daily, weekly, and monthly totals with averages from the new Study Time card in Analytics.",
         link: {
           route: "/study-time",
           label: "Open Study Time",

--- a/src/hooks/useActivityTracking.ts
+++ b/src/hooks/useActivityTracking.ts
@@ -1,0 +1,75 @@
+import { NavigationContext } from "@react-navigation/native";
+import { useContext, useEffect } from "react";
+import { timeTrackingService } from "../services/timeTrackingService";
+import type { ActivityKey } from "../services/timeTrackingCore";
+
+type ActivityTrackingOptions = {
+  /**
+   * - "mount": active from mount to unmount. For study flows (reviews,
+   *   lessons, extra study sessions): screens pushed on top (subject details,
+   *   search, ...) keep the flow mounted underneath, so its clock keeps
+   *   running until the user backs out or the flow navigates away.
+   * - "focus": active only while the screen is focused. For content screens
+   *   (news, songs, videos, EPUB reader) and tab screens, which stay mounted
+   *   when the user moves elsewhere.
+   */
+  mode?: "mount" | "focus";
+  /**
+   * Stops the clock while false, e.g. when a session shows its results
+   * screen and the study part is over.
+   */
+  enabled?: boolean;
+};
+
+/**
+ * Attributes on-screen time to an activity in the local time-tracking ledger.
+ * Only the most recently begun activity accrues time, so nesting tracked
+ * screens never double counts.
+ *
+ * Uses the optional NavigationContext instead of useFocusEffect so components
+ * can still render outside a navigator (e.g. in tests), where "focus" mode
+ * falls back to mount/unmount behavior.
+ */
+export function useActivityTracking(
+  activity: ActivityKey,
+  options: ActivityTrackingOptions = {}
+): void {
+  const { mode = "mount", enabled = true } = options;
+  const navigation = useContext(NavigationContext);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let token: number | null = null;
+    const start = () => {
+      if (token === null) {
+        token = timeTrackingService.begin(activity);
+      }
+    };
+    const stop = () => {
+      if (token !== null) {
+        timeTrackingService.end(token);
+        token = null;
+      }
+    };
+
+    if (mode !== "focus" || !navigation) {
+      start();
+      return stop;
+    }
+
+    if (navigation.isFocused()) {
+      start();
+    }
+    const unsubscribeFocus = navigation.addListener("focus", start);
+    const unsubscribeBlur = navigation.addListener("blur", stop);
+
+    return () => {
+      unsubscribeFocus();
+      unsubscribeBlur();
+      stop();
+    };
+  }, [activity, mode, enabled, navigation]);
+}

--- a/src/services/__tests__/timeTrackingCore.test.ts
+++ b/src/services/__tests__/timeTrackingCore.test.ts
@@ -1,0 +1,287 @@
+import {
+  APP_TOTAL_KEY,
+  MAX_FOLD_DELTA_MS,
+  TimeTrackingCore,
+  emptyRangeSummary,
+  addRecordToSummary,
+  getLocalDateKey,
+  splitSpanByLocalDay,
+  studyMsOfRecord,
+  summarizeRange,
+  type DayRecord,
+  type DayStore,
+} from '../timeTrackingCore';
+
+class MemoryDayStore implements DayStore {
+  map = new Map<string, DayRecord>();
+
+  getDay(dateKey: string): DayRecord | null {
+    const record = this.map.get(dateKey);
+    return record ? { ...record } : null;
+  }
+
+  setDay(dateKey: string, record: DayRecord): void {
+    this.map.set(dateKey, { ...record });
+  }
+
+  getAllDayKeys(): string[] {
+    return [...this.map.keys()].sort();
+  }
+}
+
+// Local-time timestamps keep the tests deterministic in any timezone.
+const at = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  ms = 0
+) => new Date(year, month - 1, day, hour, minute, second, ms).getTime();
+
+function makeCore(startMs: number) {
+  const store = new MemoryDayStore();
+  let now = startMs;
+  const core = new TimeTrackingCore(store, () => now);
+  const advance = (deltaMs: number) => {
+    now += deltaMs;
+  };
+  const setNow = (timestamp: number) => {
+    now = timestamp;
+  };
+  return { core, store, advance, setNow };
+}
+
+describe('splitSpanByLocalDay', () => {
+  it('keeps a same-day span in one part', () => {
+    const start = at(2026, 6, 9, 10, 0);
+    const parts = splitSpanByLocalDay(start, start + 5_000);
+    expect(parts).toEqual([{ dateKey: '2026-06-09', ms: 5_000 }]);
+  });
+
+  it('splits a span crossing midnight between both days', () => {
+    const start = at(2026, 6, 9, 23, 59, 58);
+    const end = at(2026, 6, 10, 0, 0, 3);
+    expect(splitSpanByLocalDay(start, end)).toEqual([
+      { dateKey: '2026-06-09', ms: 2_000 },
+      { dateKey: '2026-06-10', ms: 3_000 },
+    ]);
+  });
+
+  it('returns nothing for empty or inverted spans', () => {
+    const start = at(2026, 6, 9, 10, 0);
+    expect(splitSpanByLocalDay(start, start)).toEqual([]);
+    expect(splitSpanByLocalDay(start, start - 1_000)).toEqual([]);
+  });
+});
+
+describe('TimeTrackingCore', () => {
+  it('accrues app total while foregrounded with no activity', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+    advance(7_000);
+    core.fold();
+
+    expect(store.getDay('2026-06-09')).toEqual({ [APP_TOTAL_KEY]: 7_000 });
+  });
+
+  it('attributes time to the most recently begun activity', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+
+    const reviewsToken = core.begin('reviews');
+    advance(10_000);
+
+    // A focus-tracked screen opens on top of the review flow.
+    const songsToken = core.begin('songs');
+    advance(5_000);
+    core.end(songsToken);
+
+    advance(10_000);
+    core.end(reviewsToken);
+
+    const day = store.getDay('2026-06-09')!;
+    expect(day.reviews).toBe(20_000);
+    expect(day.songs).toBe(5_000);
+    expect(day[APP_TOTAL_KEY]).toBe(25_000);
+  });
+
+  it('keeps the flow activity running while neutral screens are on top', () => {
+    // Neutral screens (subject details, search) never register, so the flow
+    // simply keeps accruing — this asserts that nothing else interferes.
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+
+    const token = core.begin('reviews');
+    advance(60_000 * 0 + 30_000);
+    core.fold();
+    advance(30_000);
+    core.end(token);
+
+    expect(store.getDay('2026-06-09')!.reviews).toBe(60_000);
+  });
+
+  it('does not accrue while backgrounded and resumes cleanly', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+    core.begin('lessons');
+
+    advance(10_000);
+    core.setForeground(false); // folds the first 10s
+
+    advance(120_000); // suspended for 2 minutes
+    core.setForeground(true);
+
+    advance(5_000);
+    core.fold();
+
+    const day = store.getDay('2026-06-09')!;
+    expect(day.lessons).toBe(15_000);
+    expect(day[APP_TOTAL_KEY]).toBe(15_000);
+  });
+
+  it('splits time across local days at midnight', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 23, 59, 57));
+    core.setForeground(true);
+    core.begin('epub');
+
+    advance(6_000); // 3s before midnight + 3s after
+    core.fold();
+
+    expect(store.getDay('2026-06-09')!.epub).toBe(3_000);
+    expect(store.getDay('2026-06-10')!.epub).toBe(3_000);
+  });
+
+  it('caps implausibly large folds (missed lifecycle events)', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+    core.begin('reviews');
+
+    advance(45 * 60_000); // 45 minutes without any fold
+    core.fold();
+
+    const day = store.getDay('2026-06-09')!;
+    expect(day.reviews).toBe(MAX_FOLD_DELTA_MS);
+    expect(day[APP_TOTAL_KEY]).toBe(MAX_FOLD_DELTA_MS);
+  });
+
+  it('drops negative deltas when the clock moves backwards', () => {
+    const { core, store, advance, setNow } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+    core.begin('reviews');
+
+    setNow(at(2026, 6, 9, 9, 0)); // device clock jumped back an hour
+    core.fold();
+    expect(store.getDay('2026-06-09')).toBeNull();
+
+    advance(5_000);
+    core.fold();
+    expect(store.getDay('2026-06-09')!.reviews).toBe(5_000);
+  });
+
+  it('keeps one continuous clock when the same activity overlaps', () => {
+    // e.g. songs tab focused, then song lyrics pushed on top (both "songs").
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+
+    const tabToken = core.begin('songs');
+    advance(4_000);
+    const lyricsToken = core.begin('songs');
+    advance(4_000);
+    core.end(tabToken);
+    advance(4_000);
+    core.end(lyricsToken);
+
+    expect(store.getDay('2026-06-09')!.songs).toBe(12_000);
+  });
+
+  it('exposes live totals without persisting them', () => {
+    const { core, store, advance } = makeCore(at(2026, 6, 9, 10, 0));
+    core.setForeground(true);
+    core.begin('news');
+    advance(8_000);
+
+    const live = core.getLiveDayRecord('2026-06-09');
+    expect(live.news).toBe(8_000);
+    expect(live[APP_TOTAL_KEY]).toBe(8_000);
+    expect(store.getDay('2026-06-09')).toBeNull();
+  });
+});
+
+describe('aggregation', () => {
+  it('separates study time from app total and counts active days', () => {
+    const store = new MemoryDayStore();
+    store.setDay('2026-06-07', { reviews: 60_000, [APP_TOTAL_KEY]: 90_000 });
+    store.setDay('2026-06-08', { [APP_TOTAL_KEY]: 30_000 }); // app open, no study
+    store.setDay('2026-06-09', {
+      lessons: 30_000,
+      kana_kanji: 15_000,
+      [APP_TOTAL_KEY]: 50_000,
+    });
+
+    const summary = summarizeRange(store, '2026-06-01', '2026-06-30');
+
+    expect(summary.studyMs).toBe(105_000);
+    expect(summary.appTotalMs).toBe(170_000);
+    expect(summary.activeDayCount).toBe(2);
+    expect(summary.byCategory.reviews).toBe(60_000);
+    expect(summary.byCategory.lessons).toBe(30_000);
+    expect(summary.byCategory.extra_study).toBe(15_000);
+  });
+
+  it('uses the live record instead of the stored one for today', () => {
+    const store = new MemoryDayStore();
+    store.setDay('2026-06-09', { reviews: 10_000 });
+
+    const summary = summarizeRange(store, '2026-06-09', '2026-06-09', {
+      dateKey: '2026-06-09',
+      record: { reviews: 12_500 },
+    });
+
+    expect(summary.studyMs).toBe(12_500);
+  });
+
+  it('ignores unknown bucket keys', () => {
+    const record: DayRecord = { reviews: 1_000, some_future_key: 9_999 };
+    expect(studyMsOfRecord(record)).toBe(1_000);
+
+    const summary = emptyRangeSummary();
+    addRecordToSummary(summary, record);
+    expect(summary.studyMs).toBe(1_000);
+  });
+
+  it('maps every activity key to a category', () => {
+    const summary = emptyRangeSummary();
+    addRecordToSummary(summary, {
+      reviews: 1,
+      bunpro_reviews: 1,
+      lessons: 1,
+      bunpro_lessons: 1,
+      recent_lessons_review: 1,
+      custom_review: 1,
+      custom_lesson: 1,
+      test_session: 1,
+      meaning_reading: 1,
+      kana_kanji: 1,
+      writing_practice: 1,
+      writing_freehand: 1,
+      context_sentence: 1,
+      listening_practice: 1,
+      crossword: 1,
+      wordle: 1,
+      news: 1,
+      songs: 1,
+      epub: 1,
+      video: 1,
+    });
+    expect(summary.studyMs).toBe(20);
+  });
+});
+
+describe('getLocalDateKey', () => {
+  it('formats local dates as YYYY-MM-DD', () => {
+    expect(getLocalDateKey(at(2026, 6, 9, 0, 0))).toBe('2026-06-09');
+    expect(getLocalDateKey(at(2026, 1, 1, 23, 59))).toBe('2026-01-01');
+  });
+});

--- a/src/services/timeTrackingCore.ts
+++ b/src/services/timeTrackingCore.ts
@@ -1,0 +1,398 @@
+/**
+ * Pure, dependency-free core for app/study time tracking.
+ *
+ * Reliability model:
+ * - Time is accumulated into per-local-day, per-activity millisecond buckets.
+ * - Callers "fold" elapsed time into the buckets frequently (heartbeat). Each
+ *   fold advances the clock mark, so a fold can never be applied twice and a
+ *   process kill loses at most one heartbeat interval of time.
+ * - Only one activity accrues at a time (top of the registration stack), so
+ *   study totals never double count even when screens overlap.
+ * - All storage writes go through the injected DayStore so the platform layer
+ *   can persist synchronously (MMKV) and tests can use an in-memory map.
+ */
+
+export type ActivityKey =
+  | "reviews"
+  | "bunpro_reviews"
+  | "lessons"
+  | "bunpro_lessons"
+  | "recent_lessons_review"
+  | "custom_review"
+  | "custom_lesson"
+  | "test_session"
+  | "meaning_reading"
+  | "kana_kanji"
+  | "writing_practice"
+  | "writing_freehand"
+  | "context_sentence"
+  | "listening_practice"
+  | "crossword"
+  | "wordle"
+  | "news"
+  | "songs"
+  | "epub"
+  | "video";
+
+export type ActivityCategory =
+  | "reviews"
+  | "lessons"
+  | "extra_study"
+  | "news"
+  | "songs"
+  | "epub"
+  | "video";
+
+export const CATEGORY_BY_ACTIVITY: Record<ActivityKey, ActivityCategory> = {
+  reviews: "reviews",
+  bunpro_reviews: "reviews",
+  lessons: "lessons",
+  bunpro_lessons: "lessons",
+  recent_lessons_review: "extra_study",
+  custom_review: "extra_study",
+  custom_lesson: "extra_study",
+  test_session: "extra_study",
+  meaning_reading: "extra_study",
+  kana_kanji: "extra_study",
+  writing_practice: "extra_study",
+  writing_freehand: "extra_study",
+  context_sentence: "extra_study",
+  listening_practice: "extra_study",
+  crossword: "extra_study",
+  wordle: "extra_study",
+  news: "news",
+  songs: "songs",
+  epub: "epub",
+  video: "video",
+};
+
+export const ACTIVITY_CATEGORIES: ActivityCategory[] = [
+  "reviews",
+  "lessons",
+  "extra_study",
+  "news",
+  "songs",
+  "epub",
+  "video",
+];
+
+/** Reserved bucket key for total foreground time, kept out of study totals. */
+export const APP_TOTAL_KEY = "app_total";
+
+/** Milliseconds per bucket key (ActivityKey or APP_TOTAL_KEY). */
+export type DayRecord = Record<string, number>;
+
+export interface DayStore {
+  getDay(dateKey: string): DayRecord | null;
+  setDay(dateKey: string, record: DayRecord): void;
+  getAllDayKeys(): string[];
+}
+
+/**
+ * A single fold should never span more than this. Folds normally happen every
+ * few seconds; a larger delta means a lifecycle event was missed (e.g. the OS
+ * suspended us without notice), and counting it would inflate the totals.
+ */
+export const MAX_FOLD_DELTA_MS = 60_000;
+
+export const HEARTBEAT_INTERVAL_MS = 5_000;
+
+export function getLocalDateKey(timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function nextLocalMidnightMs(timestampMs: number): number {
+  const date = new Date(timestampMs);
+  date.setHours(24, 0, 0, 0);
+  return date.getTime();
+}
+
+export type SpanPart = { dateKey: string; ms: number };
+
+/** Split a [start, end) span into parts per local calendar day. */
+export function splitSpanByLocalDay(startMs: number, endMs: number): SpanPart[] {
+  const parts: SpanPart[] = [];
+  let cursor = startMs;
+
+  // Bounded loop: spans are already capped by MAX_FOLD_DELTA_MS, but guard
+  // against pathological input anyway.
+  for (let i = 0; cursor < endMs && i < 400; i += 1) {
+    const boundary = nextLocalMidnightMs(cursor);
+    const partEnd = Math.min(boundary, endMs);
+    const ms = partEnd - cursor;
+    if (ms > 0) {
+      parts.push({ dateKey: getLocalDateKey(cursor), ms });
+    }
+    cursor = partEnd;
+  }
+
+  return parts;
+}
+
+type Registration = {
+  token: number;
+  activity: ActivityKey;
+};
+
+export class TimeTrackingCore {
+  private store: DayStore;
+  private now: () => number;
+  private registrations: Registration[] = [];
+  private nextToken = 1;
+  private foreground = false;
+  /** Last fold point for the always-on app-total clock (null while paused). */
+  private appMarkMs: number | null = null;
+  /** Last fold point for the current activity clock (null while paused). */
+  private activityMarkMs: number | null = null;
+  private currentActivity: ActivityKey | null = null;
+
+  constructor(store: DayStore, now: () => number = Date.now) {
+    this.store = store;
+    this.now = now;
+  }
+
+  getCurrentActivity(): ActivityKey | null {
+    return this.currentActivity;
+  }
+
+  isForeground(): boolean {
+    return this.foreground;
+  }
+
+  setForeground(isForeground: boolean): boolean {
+    if (this.foreground === isForeground) {
+      return false;
+    }
+
+    // Fold while the old marks are still valid, then move the marks.
+    const changed = this.fold();
+    this.foreground = isForeground;
+    const timestamp = this.now();
+    this.appMarkMs = isForeground ? timestamp : null;
+    this.activityMarkMs =
+      isForeground && this.currentActivity !== null ? timestamp : null;
+    return changed;
+  }
+
+  begin(activity: ActivityKey): number {
+    this.fold();
+    const token = this.nextToken;
+    this.nextToken += 1;
+    this.registrations.push({ token, activity });
+    this.refreshCurrentActivity();
+    return token;
+  }
+
+  end(token: number): void {
+    this.fold();
+    this.registrations = this.registrations.filter(
+      (registration) => registration.token !== token
+    );
+    this.refreshCurrentActivity();
+  }
+
+  /**
+   * Add elapsed time since the last fold to the day buckets and advance the
+   * marks. Returns true when any bucket changed.
+   */
+  fold(): boolean {
+    if (!this.foreground) {
+      return false;
+    }
+
+    const timestamp = this.now();
+    let changed = false;
+
+    if (this.appMarkMs !== null) {
+      changed = this.addSpan(this.appMarkMs, timestamp, APP_TOTAL_KEY) || changed;
+      this.appMarkMs = timestamp;
+    }
+
+    if (this.currentActivity !== null && this.activityMarkMs !== null) {
+      changed =
+        this.addSpan(this.activityMarkMs, timestamp, this.currentActivity) ||
+        changed;
+      this.activityMarkMs = timestamp;
+    }
+
+    return changed;
+  }
+
+  /**
+   * Today's record including time elapsed since the last fold, without
+   * writing anything. Safe to call from UI on a display timer.
+   */
+  getLiveDayRecord(dateKey: string): DayRecord {
+    const record: DayRecord = { ...(this.store.getDay(dateKey) ?? {}) };
+
+    if (!this.foreground) {
+      return record;
+    }
+
+    const timestamp = this.now();
+    const addLivePart = (startMs: number | null, key: string) => {
+      if (startMs === null) {
+        return;
+      }
+      for (const part of clampedSpanParts(startMs, timestamp)) {
+        if (part.dateKey === dateKey) {
+          record[key] = (record[key] ?? 0) + part.ms;
+        }
+      }
+    };
+
+    addLivePart(this.appMarkMs, APP_TOTAL_KEY);
+    if (this.currentActivity !== null) {
+      addLivePart(this.activityMarkMs, this.currentActivity);
+    }
+
+    return record;
+  }
+
+  private refreshCurrentActivity(): void {
+    const top =
+      this.registrations.length > 0
+        ? this.registrations[this.registrations.length - 1].activity
+        : null;
+
+    if (top === this.currentActivity) {
+      return;
+    }
+
+    this.currentActivity = top;
+    this.activityMarkMs =
+      this.foreground && top !== null ? this.now() : null;
+  }
+
+  private addSpan(startMs: number, endMs: number, key: string): boolean {
+    const parts = clampedSpanParts(startMs, endMs);
+    if (parts.length === 0) {
+      return false;
+    }
+
+    for (const part of parts) {
+      const record = this.store.getDay(part.dateKey) ?? {};
+      record[key] = (record[key] ?? 0) + part.ms;
+      this.store.setDay(part.dateKey, record);
+    }
+
+    return true;
+  }
+}
+
+function clampedSpanParts(startMs: number, endMs: number): SpanPart[] {
+  const delta = endMs - startMs;
+  if (!Number.isFinite(delta) || delta <= 0) {
+    return [];
+  }
+
+  // If a fold arrives implausibly late (missed lifecycle event, device clock
+  // jump), only credit the most recent MAX_FOLD_DELTA_MS.
+  const clampedStart = delta > MAX_FOLD_DELTA_MS ? endMs - MAX_FOLD_DELTA_MS : startMs;
+  return splitSpanByLocalDay(clampedStart, endMs);
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers (pure, used by the stats UI and the sync payloads)
+// ---------------------------------------------------------------------------
+
+export type RangeSummary = {
+  /** Total study milliseconds (all tracked activities, app total excluded). */
+  studyMs: number;
+  appTotalMs: number;
+  byCategory: Record<ActivityCategory, number>;
+  byActivity: Partial<Record<ActivityKey, number>>;
+  /** Days in the range with any study time. */
+  activeDayCount: number;
+};
+
+export function emptyRangeSummary(): RangeSummary {
+  const byCategory = {} as Record<ActivityCategory, number>;
+  for (const category of ACTIVITY_CATEGORIES) {
+    byCategory[category] = 0;
+  }
+  return {
+    studyMs: 0,
+    appTotalMs: 0,
+    byCategory,
+    byActivity: {},
+    activeDayCount: 0,
+  };
+}
+
+export function studyMsOfRecord(record: DayRecord): number {
+  let total = 0;
+  for (const [key, ms] of Object.entries(record)) {
+    if (key in CATEGORY_BY_ACTIVITY && Number.isFinite(ms) && ms > 0) {
+      total += ms;
+    }
+  }
+  return total;
+}
+
+export function addRecordToSummary(summary: RangeSummary, record: DayRecord): void {
+  let dayStudyMs = 0;
+
+  for (const [key, ms] of Object.entries(record)) {
+    if (!Number.isFinite(ms) || ms <= 0) {
+      continue;
+    }
+
+    if (key === APP_TOTAL_KEY) {
+      summary.appTotalMs += ms;
+      continue;
+    }
+
+    const category = CATEGORY_BY_ACTIVITY[key as ActivityKey];
+    if (!category) {
+      continue;
+    }
+
+    summary.byCategory[category] += ms;
+    summary.byActivity[key as ActivityKey] =
+      (summary.byActivity[key as ActivityKey] ?? 0) + ms;
+    dayStudyMs += ms;
+  }
+
+  summary.studyMs += dayStudyMs;
+  if (dayStudyMs > 0) {
+    summary.activeDayCount += 1;
+  }
+}
+
+/** Inclusive [startKey, endKey] summary over stored days. */
+export function summarizeRange(
+  store: DayStore,
+  startKey: string,
+  endKey: string,
+  liveRecordForDay?: { dateKey: string; record: DayRecord }
+): RangeSummary {
+  const summary = emptyRangeSummary();
+
+  for (const dateKey of store.getAllDayKeys()) {
+    if (dateKey < startKey || dateKey > endKey) {
+      continue;
+    }
+    if (liveRecordForDay && dateKey === liveRecordForDay.dateKey) {
+      continue;
+    }
+    const record = store.getDay(dateKey);
+    if (record) {
+      addRecordToSummary(summary, record);
+    }
+  }
+
+  if (
+    liveRecordForDay &&
+    liveRecordForDay.dateKey >= startKey &&
+    liveRecordForDay.dateKey <= endKey
+  ) {
+    addRecordToSummary(summary, liveRecordForDay.record);
+  }
+
+  return summary;
+}

--- a/src/services/timeTrackingService.ts
+++ b/src/services/timeTrackingService.ts
@@ -1,0 +1,234 @@
+import { AppState, type AppStateStatus } from "react-native";
+import { MMKV } from "react-native-mmkv";
+import {
+  HEARTBEAT_INTERVAL_MS,
+  TimeTrackingCore,
+  getLocalDateKey,
+  studyMsOfRecord,
+  summarizeRange,
+  type ActivityKey,
+  type DayRecord,
+  type DayStore,
+  type RangeSummary,
+} from "./timeTrackingCore";
+
+const DAY_KEY_PREFIX = "ttv1.day.";
+const MAX_HISTORY_DAYS = 400;
+
+// Dedicated instance so frequent small heartbeat writes never contend with the
+// main app cache, and the data survives cache clears.
+const timeTrackingStorage = new MMKV({ id: "kakehashi-time-tracking" });
+
+class MmkvDayStore implements DayStore {
+  private cache = new Map<string, DayRecord>();
+
+  getDay(dateKey: string): DayRecord | null {
+    const cached = this.cache.get(dateKey);
+    if (cached) {
+      return cached;
+    }
+
+    try {
+      const raw = timeTrackingStorage.getString(DAY_KEY_PREFIX + dateKey);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as DayRecord;
+      if (!parsed || typeof parsed !== "object") {
+        return null;
+      }
+      this.cache.set(dateKey, parsed);
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  setDay(dateKey: string, record: DayRecord): void {
+    this.cache.set(dateKey, record);
+    try {
+      // Synchronous MMKV write: this is the crash-safety point. Once this
+      // returns, the folded time is durable even if the process dies.
+      timeTrackingStorage.set(DAY_KEY_PREFIX + dateKey, JSON.stringify(record));
+    } catch (error) {
+      console.error("Failed to persist time tracking day record:", error);
+    }
+  }
+
+  getAllDayKeys(): string[] {
+    try {
+      return timeTrackingStorage
+        .getAllKeys()
+        .filter((key) => key.startsWith(DAY_KEY_PREFIX))
+        .map((key) => key.slice(DAY_KEY_PREFIX.length))
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
+  deleteDay(dateKey: string): void {
+    this.cache.delete(dateKey);
+    try {
+      timeTrackingStorage.delete(DAY_KEY_PREFIX + dateKey);
+    } catch {
+      // Pruning is best-effort.
+    }
+  }
+}
+
+class TimeTrackingService {
+  private dayStore = new MmkvDayStore();
+  private core = new TimeTrackingCore(this.dayStore);
+  private initialized = false;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTickCount = 0;
+  private onSyncOpportunity: (() => void) | null = null;
+
+  /** Idempotent; called once from the root layout. */
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+    this.initialized = true;
+
+    this.core.setForeground(AppState.currentState === "active");
+    this.updateHeartbeat();
+
+    AppState.addEventListener("change", this.handleAppStateChange);
+
+    this.pruneOldDays();
+  }
+
+  /**
+   * The sync layer registers here so the tracker can ping it at good moments
+   * (foreground transitions, periodic while active) without a circular import.
+   */
+  setOnSyncOpportunity(callback: (() => void) | null): void {
+    this.onSyncOpportunity = callback;
+  }
+
+  begin(activity: ActivityKey): number {
+    return this.core.begin(activity);
+  }
+
+  end(token: number): void {
+    this.core.end(token);
+  }
+
+  /** Persist any unfolded elapsed time right now (used before sync reads). */
+  foldNow(): void {
+    this.core.fold();
+  }
+
+  getCurrentActivity(): ActivityKey | null {
+    return this.core.getCurrentActivity();
+  }
+
+  getTodayDateKey(): string {
+    return getLocalDateKey(Date.now());
+  }
+
+  /** Today's record including the still-running clocks; read-only. */
+  getLiveToday(): DayRecord {
+    return this.core.getLiveDayRecord(this.getTodayDateKey());
+  }
+
+  /** Inclusive range summary; today's live time is included when in range. */
+  getSummaryBetween(startKey: string, endKey: string): RangeSummary {
+    const todayKey = this.getTodayDateKey();
+    return summarizeRange(this.dayStore, startKey, endKey, {
+      dateKey: todayKey,
+      record: this.core.getLiveDayRecord(todayKey),
+    });
+  }
+
+  getAllTimeSummary(): { summary: RangeSummary; firstDayKey: string | null } {
+    const keys = this.dayStore.getAllDayKeys();
+    const todayKey = this.getTodayDateKey();
+    const firstDayKey = keys.length > 0 ? keys[0] : todayKey;
+    return {
+      summary: this.getSummaryBetween(firstDayKey, todayKey),
+      firstDayKey: keys.length > 0 ? keys[0] : null,
+    };
+  }
+
+  /** Study totals for the last `dayCount` calendar days (today last, live). */
+  getDailyStudySeries(dayCount: number): { dateKey: string; studyMs: number }[] {
+    const series: { dateKey: string; studyMs: number }[] = [];
+    const todayKey = this.getTodayDateKey();
+
+    for (let offset = dayCount - 1; offset >= 0; offset -= 1) {
+      const date = new Date();
+      date.setDate(date.getDate() - offset);
+      const dateKey = getLocalDateKey(date.getTime());
+      const record =
+        dateKey === todayKey
+          ? this.core.getLiveDayRecord(dateKey)
+          : this.dayStore.getDay(dateKey);
+      series.push({ dateKey, studyMs: record ? studyMsOfRecord(record) : 0 });
+    }
+
+    return series;
+  }
+
+  /** Persisted (folded) records for the most recent days, oldest first. */
+  getRecentDayRecords(dayCount: number): { dateKey: string; record: DayRecord }[] {
+    const keys = this.dayStore.getAllDayKeys();
+    return keys.slice(-dayCount).map((dateKey) => ({
+      dateKey,
+      record: this.dayStore.getDay(dateKey) ?? {},
+    }));
+  }
+
+  private handleAppStateChange = (nextState: AppStateStatus) => {
+    const isActive = nextState === "active";
+    const wasForeground = this.core.isForeground();
+    this.core.setForeground(isActive);
+    this.updateHeartbeat();
+
+    // Sync on both transitions: leaving the app captures the session that
+    // just ended (best effort — the upsert is duplicate-safe so a dropped
+    // request is harmless), returning retries anything that was missed.
+    if (isActive !== wasForeground) {
+      this.onSyncOpportunity?.();
+    }
+  };
+
+  private updateHeartbeat(): void {
+    const shouldRun = this.core.isForeground();
+
+    if (shouldRun && this.heartbeatTimer === null) {
+      this.heartbeatTimer = setInterval(() => {
+        this.core.fold();
+        this.heartbeatTickCount += 1;
+        // Roughly every 5 minutes of active use.
+        if (this.heartbeatTickCount % 60 === 0) {
+          this.onSyncOpportunity?.();
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+    } else if (!shouldRun && this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private pruneOldDays(): void {
+    try {
+      const minDate = new Date();
+      minDate.setDate(minDate.getDate() - MAX_HISTORY_DAYS);
+      const minKey = getLocalDateKey(minDate.getTime());
+
+      for (const dateKey of this.dayStore.getAllDayKeys()) {
+        if (dateKey < minKey) {
+          this.dayStore.deleteDay(dateKey);
+        }
+      }
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+}
+
+export const timeTrackingService = new TimeTrackingService();
+export { timeTrackingStorage };

--- a/src/services/timeTrackingSyncService.ts
+++ b/src/services/timeTrackingSyncService.ts
@@ -107,7 +107,7 @@ function buildActivityMs(record: DayRecord): Partial<Record<ActivityKey, number>
 }
 
 async function syncNow(): Promise<void> {
-  if (!isSupabaseConfigured || didWarnAboutMissingTable) {
+  if (!isSupabaseConfigured) {
     return;
   }
 
@@ -155,6 +155,8 @@ async function syncNow(): Promise<void> {
 
   if (error) {
     if (isMissingTableError(error)) {
+      // Keep retrying on later opportunities (the table may be created while
+      // the app is running); only the warning is one-time.
       if (!didWarnAboutMissingTable) {
         didWarnAboutMissingTable = true;
         console.warn(

--- a/src/services/timeTrackingSyncService.ts
+++ b/src/services/timeTrackingSyncService.ts
@@ -25,6 +25,7 @@ import { timeTrackingService, timeTrackingStorage } from "./timeTrackingService"
 const DEVICE_ID_KEY = "ttv1.device_id";
 const PUSHED_SUMS_KEY = "ttv1.sync.pushed_sums";
 const TABLE_NAME = "study_time_days";
+const UPSERT_FUNCTION_NAME = "upsert_study_time_days";
 
 const MIN_SYNC_INTERVAL_MS = 90 * 1000;
 const MAX_DAYS_PER_SYNC = 14;
@@ -62,7 +63,7 @@ export function getStudyTimeSyncStatus(): StudyTimeSyncStatus {
   return syncStatus;
 }
 
-function isMissingTableError(error: unknown): boolean {
+function isMissingSyncTargetError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -70,8 +71,12 @@ function isMissingTableError(error: unknown): boolean {
   const code = String((error as { code?: unknown }).code ?? "");
   const message = String((error as { message?: unknown }).message ?? "").toLowerCase();
   return (
-    code === "42P01" ||
-    (message.includes("does not exist") && message.includes(TABLE_NAME))
+    code === "42P01" || // table missing
+    code === "42883" || // function missing
+    code === "PGRST202" || // PostgREST: function not in schema cache
+    (message.includes("does not exist") && message.includes(TABLE_NAME)) ||
+    (message.includes("could not find the function") &&
+      message.includes(UPSERT_FUNCTION_NAME))
   );
 }
 
@@ -183,23 +188,24 @@ async function syncNow(): Promise<void> {
     updated_at: nowIso,
   }));
 
-  const { error } = await supabase
-    .from(TABLE_NAME)
-    .upsert(rows, { onConflict: "user_id,device_id,day" });
+  // A security definer RPC is the only write path: clients have no table
+  // privileges at all, which keeps the data unreadable and avoids the SELECT
+  // requirement PostgREST upserts have for conflict detection.
+  const { error } = await supabase.rpc(UPSERT_FUNCTION_NAME, { rows });
 
   if (error) {
-    if (isMissingTableError(error)) {
-      // Keep retrying on later opportunities (the table may be created while
-      // the app is running); only the warning is one-time.
+    if (isMissingSyncTargetError(error)) {
+      // Keep retrying on later opportunities (the migration may be applied
+      // while the app is running); only the warning is one-time.
       if (!didWarnAboutMissingTable) {
         didWarnAboutMissingTable = true;
         console.warn(
-          `Time tracking sync table is missing. Run the ${TABLE_NAME} migration to enable it.`
+          `Time tracking sync target is missing. Run the ${TABLE_NAME} migration to enable it.`
         );
       }
       setSyncStatus(
         "error",
-        `Table "${TABLE_NAME}" not found — run the migration in Supabase`
+        `Function "${UPSERT_FUNCTION_NAME}" not found — run the latest migration in Supabase`
       );
       return;
     }

--- a/src/services/timeTrackingSyncService.ts
+++ b/src/services/timeTrackingSyncService.ts
@@ -1,0 +1,211 @@
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+import { isSupabaseConfigured, supabase } from "../lib/supabase";
+import { useAuthStore } from "../utils/store";
+import {
+  APP_TOTAL_KEY,
+  CATEGORY_BY_ACTIVITY,
+  studyMsOfRecord,
+  type ActivityKey,
+  type DayRecord,
+} from "./timeTrackingCore";
+import { timeTrackingService, timeTrackingStorage } from "./timeTrackingService";
+
+/**
+ * Pushes time tracking totals to Supabase for developer analytics.
+ *
+ * Reliability properties:
+ * - Rows carry ABSOLUTE day totals keyed by (user_id, device_id, day) and are
+ *   upserted. Retries, duplicate requests and out-of-order delivery all
+ *   converge on the same value — nothing is ever added twice.
+ * - Local MMKV stays the source of truth; this sync is fire-and-forget and
+ *   the app never depends on it succeeding.
+ */
+
+const DEVICE_ID_KEY = "ttv1.device_id";
+const PUSHED_SUMS_KEY = "ttv1.sync.pushed_sums";
+const TABLE_NAME = "study_time_days";
+
+const MIN_SYNC_INTERVAL_MS = 90 * 1000;
+const MAX_DAYS_PER_SYNC = 14;
+
+let lastAttemptAtMs = 0;
+let isSyncing = false;
+let didWarnAboutMissingTable = false;
+
+function isMissingTableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = String((error as { code?: unknown }).code ?? "");
+  const message = String((error as { message?: unknown }).message ?? "").toLowerCase();
+  return (
+    code === "42P01" ||
+    (message.includes("does not exist") && message.includes(TABLE_NAME))
+  );
+}
+
+function getDeviceId(): string {
+  try {
+    const existing = timeTrackingStorage.getString(DEVICE_ID_KEY);
+    if (existing) {
+      return existing;
+    }
+
+    const generated = `${Date.now().toString(36)}-${Math.random()
+      .toString(36)
+      .slice(2, 10)}-${Math.random().toString(36).slice(2, 10)}`;
+    timeTrackingStorage.set(DEVICE_ID_KEY, generated);
+    return generated;
+  } catch {
+    return "unknown-device";
+  }
+}
+
+function readPushedSums(): Record<string, number> {
+  try {
+    const raw = timeTrackingStorage.getString(PUSHED_SUMS_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw) as Record<string, number>;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writePushedSums(sums: Record<string, number>): void {
+  try {
+    timeTrackingStorage.set(PUSHED_SUMS_KEY, JSON.stringify(sums));
+  } catch {
+    // Best effort; worst case we re-push identical absolute values.
+  }
+}
+
+/** Total of every bucket in the record. Only ever grows, so it doubles as a
+ * cheap dirty-detection version number. */
+function recordSum(record: DayRecord): number {
+  let total = 0;
+  for (const value of Object.values(record)) {
+    if (Number.isFinite(value) && value > 0) {
+      total += value;
+    }
+  }
+  return total;
+}
+
+function buildActivityMs(record: DayRecord): Partial<Record<ActivityKey, number>> {
+  const activityMs: Partial<Record<ActivityKey, number>> = {};
+  for (const [key, ms] of Object.entries(record)) {
+    if (key in CATEGORY_BY_ACTIVITY && Number.isFinite(ms) && ms > 0) {
+      activityMs[key as ActivityKey] = Math.round(ms);
+    }
+  }
+  return activityMs;
+}
+
+async function syncNow(): Promise<void> {
+  if (!isSupabaseConfigured || didWarnAboutMissingTable) {
+    return;
+  }
+
+  const userData = useAuthStore.getState().userData;
+  if (!userData?.id) {
+    return;
+  }
+
+  // Persist the running clocks so the rows below reflect everything.
+  timeTrackingService.foldNow();
+
+  const recentDays = timeTrackingService.getRecentDayRecords(MAX_DAYS_PER_SYNC);
+  const pushedSums = readPushedSums();
+
+  const dirtyDays = recentDays.filter(({ dateKey, record }) => {
+    const sum = recordSum(record);
+    return sum > 0 && sum > (pushedSums[dateKey] ?? 0);
+  });
+
+  if (dirtyDays.length === 0) {
+    return;
+  }
+
+  const deviceId = getDeviceId();
+  const appVersion = Constants.expoConfig?.version ?? null;
+  const nowIso = new Date().toISOString();
+
+  const rows = dirtyDays.map(({ dateKey, record }) => ({
+    user_id: userData.id,
+    device_id: deviceId,
+    day: dateKey,
+    activity_ms: buildActivityMs(record),
+    study_total_ms: Math.round(studyMsOfRecord(record)),
+    app_total_ms: Math.round(record[APP_TOTAL_KEY] ?? 0),
+    user_name: userData.username ?? null,
+    user_level: userData.level ?? null,
+    app_version: appVersion,
+    platform: Platform.OS,
+    updated_at: nowIso,
+  }));
+
+  const { error } = await supabase
+    .from(TABLE_NAME)
+    .upsert(rows, { onConflict: "user_id,device_id,day" });
+
+  if (error) {
+    if (isMissingTableError(error)) {
+      if (!didWarnAboutMissingTable) {
+        didWarnAboutMissingTable = true;
+        console.warn(
+          `Time tracking sync table is missing. Run the ${TABLE_NAME} migration to enable it.`
+        );
+      }
+      return;
+    }
+    // Leave pushed sums untouched; the next opportunity re-sends the same
+    // absolute values, which is safe.
+    console.log("📊 Could not sync study time:", error.message);
+    return;
+  }
+
+  const nextPushedSums = { ...pushedSums };
+  for (const { dateKey, record } of dirtyDays) {
+    nextPushedSums[dateKey] = recordSum(record);
+  }
+  // Drop markers for days outside the sync window to keep the blob tiny.
+  const windowKeys = new Set(recentDays.map(({ dateKey }) => dateKey));
+  for (const key of Object.keys(nextPushedSums)) {
+    if (!windowKeys.has(key)) {
+      delete nextPushedSums[key];
+    }
+  }
+  writePushedSums(nextPushedSums);
+}
+
+export function maybeSyncStudyTime(): void {
+  const now = Date.now();
+  if (isSyncing || now - lastAttemptAtMs < MIN_SYNC_INTERVAL_MS) {
+    return;
+  }
+
+  lastAttemptAtMs = now;
+  isSyncing = true;
+  syncNow()
+    .catch((error) => {
+      console.log("📊 Study time sync failed:", error?.message ?? error);
+    })
+    .finally(() => {
+      isSyncing = false;
+    });
+}
+
+/** Wires the sync into the tracker's opportunity callback. Idempotent. */
+export function initializeTimeTrackingSync(): void {
+  timeTrackingService.setOnSyncOpportunity(maybeSyncStudyTime);
+
+  // First push shortly after startup, off the critical path.
+  setTimeout(() => {
+    maybeSyncStudyTime();
+  }, 10_000);
+}

--- a/src/services/timeTrackingSyncService.ts
+++ b/src/services/timeTrackingSyncService.ts
@@ -33,6 +33,35 @@ let lastAttemptAtMs = 0;
 let isSyncing = false;
 let didWarnAboutMissingTable = false;
 
+export type StudyTimeSyncStatus = {
+  state: "never" | "syncing" | "success" | "skipped" | "error";
+  /** Human-readable outcome of the last attempt, shown in the app. */
+  detail: string;
+  at: number | null;
+  lastSuccessAt: number | null;
+};
+
+let syncStatus: StudyTimeSyncStatus = {
+  state: "never",
+  detail: "No sync attempted yet",
+  at: null,
+  lastSuccessAt: null,
+};
+
+function setSyncStatus(state: StudyTimeSyncStatus["state"], detail: string): void {
+  syncStatus = {
+    state,
+    detail,
+    at: Date.now(),
+    lastSuccessAt: state === "success" ? Date.now() : syncStatus.lastSuccessAt,
+  };
+}
+
+/** Read by the Study Time screen so device testers can see sync results. */
+export function getStudyTimeSyncStatus(): StudyTimeSyncStatus {
+  return syncStatus;
+}
+
 function isMissingTableError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
@@ -46,7 +75,7 @@ function isMissingTableError(error: unknown): boolean {
   );
 }
 
-function getDeviceId(): string {
+export function getDeviceId(): string {
   try {
     const existing = timeTrackingStorage.getString(DEVICE_ID_KEY);
     if (existing) {
@@ -108,13 +137,17 @@ function buildActivityMs(record: DayRecord): Partial<Record<ActivityKey, number>
 
 async function syncNow(): Promise<void> {
   if (!isSupabaseConfigured) {
+    setSyncStatus("skipped", "Supabase is not configured in this build");
     return;
   }
 
   const userData = useAuthStore.getState().userData;
   if (!userData?.id) {
+    setSyncStatus("skipped", "Waiting for login (no user data yet)");
     return;
   }
+
+  setSyncStatus("syncing", "Pushing day totals…");
 
   // Persist the running clocks so the rows below reflect everything.
   timeTrackingService.foldNow();
@@ -128,6 +161,7 @@ async function syncNow(): Promise<void> {
   });
 
   if (dirtyDays.length === 0) {
+    setSyncStatus("success", "Up to date — nothing new to push");
     return;
   }
 
@@ -163,13 +197,23 @@ async function syncNow(): Promise<void> {
           `Time tracking sync table is missing. Run the ${TABLE_NAME} migration to enable it.`
         );
       }
+      setSyncStatus(
+        "error",
+        `Table "${TABLE_NAME}" not found — run the migration in Supabase`
+      );
       return;
     }
     // Leave pushed sums untouched; the next opportunity re-sends the same
     // absolute values, which is safe.
     console.log("📊 Could not sync study time:", error.message);
+    setSyncStatus("error", error.message);
     return;
   }
+
+  setSyncStatus(
+    "success",
+    `Pushed ${dirtyDays.length} day${dirtyDays.length === 1 ? "" : "s"}`
+  );
 
   const nextPushedSums = { ...pushedSums };
   for (const { dateKey, record } of dirtyDays) {
@@ -185,9 +229,9 @@ async function syncNow(): Promise<void> {
   writePushedSums(nextPushedSums);
 }
 
-export function maybeSyncStudyTime(): void {
+export function maybeSyncStudyTime(options: { force?: boolean } = {}): void {
   const now = Date.now();
-  if (isSyncing || now - lastAttemptAtMs < MIN_SYNC_INTERVAL_MS) {
+  if (isSyncing || (!options.force && now - lastAttemptAtMs < MIN_SYNC_INTERVAL_MS)) {
     return;
   }
 
@@ -196,6 +240,7 @@ export function maybeSyncStudyTime(): void {
   syncNow()
     .catch((error) => {
       console.log("📊 Study time sync failed:", error?.message ?? error);
+      setSyncStatus("error", String(error?.message ?? error));
     })
     .finally(() => {
       isSyncing = false;

--- a/src/utils/durationFormat.ts
+++ b/src/utils/durationFormat.ts
@@ -1,0 +1,30 @@
+/** "1h 23m", "12m 45s", "32s". Always returns something readable. */
+export function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor((ms || 0) / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+/** Coarse variant for averages and summaries: "1h 23m", "12m", "<1m". */
+export function formatDurationMsCoarse(ms: number): string {
+  const totalMinutes = Math.floor(Math.max(0, ms || 0) / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return ms > 0 ? "<1m" : "0m";
+}

--- a/src/utils/homeWidgets.ts
+++ b/src/utils/homeWidgets.ts
@@ -14,6 +14,7 @@ export type HomeWidgetId =
   | "levelTiming"
   | "reviewStats"
   | "dailyStudyActivity"
+  | "studyTime"
   | "srsBreakdown";
 
 export type HomeWidgetSourceTab = "home" | "level" | "items" | "analytics";
@@ -114,6 +115,12 @@ export const HOME_WIDGET_DEFINITIONS: HomeWidgetDefinition[] = [
     id: "dailyStudyActivity",
     title: "Today's Study",
     description: "Lessons and reviews completed today.",
+    sourceTab: "analytics",
+  },
+  {
+    id: "studyTime",
+    title: "Study Time",
+    description: "Device-tracked time spent studying today.",
     sourceTab: "analytics",
   },
   {

--- a/src/utils/studyTimeRanges.ts
+++ b/src/utils/studyTimeRanges.ts
@@ -1,0 +1,218 @@
+import { startOfMonth, startOfWeek } from "date-fns";
+import { getLocalDateKey, type RangeSummary } from "../services/timeTrackingCore";
+import { timeTrackingService } from "../services/timeTrackingService";
+
+export type StudyTimeRangeId = "today" | "week" | "month" | "all";
+export type StudyTimeChartUnit = "day" | "week" | "month";
+
+export type StudyTimeChartBucket = {
+  id: string;
+  startKey: string;
+  endKey: string;
+  label: string;
+  accessibilityLabel: string;
+  studyMs: number;
+  isCurrent: boolean;
+};
+
+export type StudyTimeRangeData = {
+  summary: RangeSummary;
+  startKey: string;
+  endKey: string;
+  elapsedDays: number;
+  series: StudyTimeChartBucket[];
+  chartTitle: string;
+  chartUnit: StudyTimeChartUnit;
+};
+
+export const STUDY_TIME_RANGE_LABELS = ["Today", "Week", "Month", "All"];
+export const STUDY_TIME_RANGE_IDS: StudyTimeRangeId[] = [
+  "today",
+  "week",
+  "month",
+  "all",
+];
+
+const DEFAULT_BUCKET_COUNT = 14;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+export function parseStudyTimeDateKey(dateKey: string): Date {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+}
+
+export function daysBetweenInclusive(startKey: string, endKey: string): number {
+  const diff = Math.round(
+    (parseStudyTimeDateKey(endKey).getTime() -
+      parseStudyTimeDateKey(startKey).getTime()) /
+      ONE_DAY_MS,
+  );
+  return Math.max(1, diff + 1);
+}
+
+function getRangeStartKey(range: StudyTimeRangeId, now: Date): string {
+  if (range === "week") {
+    return getLocalDateKey(startOfWeek(now, { weekStartsOn: 1 }).getTime());
+  }
+
+  if (range === "month") {
+    return getLocalDateKey(startOfMonth(now).getTime());
+  }
+
+  if (range === "all") {
+    const { firstDayKey } = timeTrackingService.getAllTimeSummary();
+    return firstDayKey ?? getLocalDateKey(now.getTime());
+  }
+
+  return getLocalDateKey(now.getTime());
+}
+
+function formatDayLabel(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, { weekday: "short" })
+    .format(date)
+    .slice(0, 1)
+    .toUpperCase();
+}
+
+function formatMonthDay(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+function formatMonthLabel(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, { month: "short" }).format(date);
+}
+
+function formatFullDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function buildDayBuckets(now: Date, bucketCount: number): StudyTimeChartBucket[] {
+  const todayKey = getLocalDateKey(now.getTime());
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const offset = bucketCount - 1 - index;
+    const date = addDays(now, -offset);
+    const dateKey = getLocalDateKey(date.getTime());
+    const summary = timeTrackingService.getSummaryBetween(dateKey, dateKey);
+
+    return {
+      id: dateKey,
+      startKey: dateKey,
+      endKey: dateKey,
+      label: formatDayLabel(date),
+      accessibilityLabel: formatFullDate(date),
+      studyMs: summary.studyMs,
+      isCurrent: dateKey === todayKey,
+    };
+  });
+}
+
+function buildWeekBuckets(now: Date, bucketCount: number): StudyTimeChartBucket[] {
+  const currentWeekStart = startOfWeek(now, { weekStartsOn: 1 });
+  const todayKey = getLocalDateKey(now.getTime());
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const offset = bucketCount - 1 - index;
+    const start = addDays(currentWeekStart, -offset * 7);
+    const end = offset === 0 ? now : addDays(start, 6);
+    const startKey = getLocalDateKey(start.getTime());
+    const endKey = getLocalDateKey(end.getTime());
+    const summary = timeTrackingService.getSummaryBetween(startKey, endKey);
+
+    return {
+      id: `${startKey}:${endKey}`,
+      startKey,
+      endKey,
+      label: formatMonthDay(start),
+      accessibilityLabel: `Week of ${formatMonthDay(start)}`,
+      studyMs: summary.studyMs,
+      isCurrent: startKey <= todayKey && todayKey <= endKey,
+    };
+  });
+}
+
+function buildMonthBuckets(now: Date, bucketCount: number): StudyTimeChartBucket[] {
+  const currentMonthStart = startOfMonth(now);
+  const todayKey = getLocalDateKey(now.getTime());
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const offset = bucketCount - 1 - index;
+    const start = addMonths(currentMonthStart, -offset);
+    const monthEnd = new Date(start.getFullYear(), start.getMonth() + 1, 0);
+    const end = offset === 0 ? now : monthEnd;
+    const startKey = getLocalDateKey(start.getTime());
+    const endKey = getLocalDateKey(end.getTime());
+    const summary = timeTrackingService.getSummaryBetween(startKey, endKey);
+
+    return {
+      id: `${startKey}:${endKey}`,
+      startKey,
+      endKey,
+      label: formatMonthLabel(start),
+      accessibilityLabel: start.toLocaleDateString(undefined, {
+        month: "long",
+        year: "numeric",
+      }),
+      studyMs: summary.studyMs,
+      isCurrent: startKey <= todayKey && todayKey <= endKey,
+    };
+  });
+}
+
+export function getStudyTimeChartConfig(range: StudyTimeRangeId): {
+  chartTitle: string;
+  chartUnit: StudyTimeChartUnit;
+} {
+  if (range === "week") {
+    return { chartTitle: "Last 14 weeks", chartUnit: "week" };
+  }
+
+  if (range === "month" || range === "all") {
+    return { chartTitle: "Last 14 months", chartUnit: "month" };
+  }
+
+  return { chartTitle: "Last 14 days", chartUnit: "day" };
+}
+
+export function readStudyTimeRangeData(
+  range: StudyTimeRangeId,
+  bucketCount = DEFAULT_BUCKET_COUNT,
+): StudyTimeRangeData {
+  const now = new Date();
+  const todayKey = getLocalDateKey(now.getTime());
+  const startKey = getRangeStartKey(range, now);
+  const { chartTitle, chartUnit } = getStudyTimeChartConfig(range);
+  const series =
+    chartUnit === "week"
+      ? buildWeekBuckets(now, bucketCount)
+      : chartUnit === "month"
+        ? buildMonthBuckets(now, bucketCount)
+        : buildDayBuckets(now, bucketCount);
+
+  return {
+    summary: timeTrackingService.getSummaryBetween(startKey, todayKey),
+    startKey,
+    endKey: todayKey,
+    elapsedDays: daysBetweenInclusive(startKey, todayKey),
+    series,
+    chartTitle,
+    chartUnit,
+  };
+}

--- a/src/utils/studyTimeRanges.ts
+++ b/src/utils/studyTimeRanges.ts
@@ -1,5 +1,9 @@
 import { startOfMonth, startOfWeek } from "date-fns";
-import { getLocalDateKey, type RangeSummary } from "../services/timeTrackingCore";
+import {
+  getLocalDateKey,
+  type ActivityCategory,
+  type RangeSummary,
+} from "../services/timeTrackingCore";
 import { timeTrackingService } from "../services/timeTrackingService";
 
 export type StudyTimeRangeId = "today" | "week" | "month" | "all";
@@ -12,6 +16,7 @@ export type StudyTimeChartBucket = {
   label: string;
   accessibilityLabel: string;
   studyMs: number;
+  byCategory: Record<ActivityCategory, number>;
   isCurrent: boolean;
 };
 
@@ -119,6 +124,7 @@ function buildDayBuckets(now: Date, bucketCount: number): StudyTimeChartBucket[]
       label: formatDayLabel(date),
       accessibilityLabel: formatFullDate(date),
       studyMs: summary.studyMs,
+      byCategory: summary.byCategory,
       isCurrent: dateKey === todayKey,
     };
   });
@@ -143,6 +149,7 @@ function buildWeekBuckets(now: Date, bucketCount: number): StudyTimeChartBucket[
       label: formatMonthDay(start),
       accessibilityLabel: `Week of ${formatMonthDay(start)}`,
       studyMs: summary.studyMs,
+      byCategory: summary.byCategory,
       isCurrent: startKey <= todayKey && todayKey <= endKey,
     };
   });
@@ -171,6 +178,7 @@ function buildMonthBuckets(now: Date, bucketCount: number): StudyTimeChartBucket
         year: "numeric",
       }),
       studyMs: summary.studyMs,
+      byCategory: summary.byCategory,
       isCurrent: startKey <= todayKey && todayKey <= endKey,
     };
   });

--- a/supabase/migrations/20260609000000_study_time_days.sql
+++ b/supabase/migrations/20260609000000_study_time_days.sql
@@ -46,18 +46,21 @@ grant select, insert, update on public.study_time_days to anon, authenticated;
 
 -- Same trust model as app_sessions: clients write with the anon key but can
 -- never read usage data back. Developer access goes through the dashboard or
--- the service role, which bypass RLS.
-drop policy if exists "Clients can insert study time rows" on public.study_time_days;
-create policy "Clients can insert study time rows"
-  on public.study_time_days
-  for insert
-  to anon, authenticated
-  with check (true);
+-- the service role, which bypass RLS. Policies are recreated from scratch
+-- (dropping any leftovers, including restrictive ones) and apply to all
+-- roles so nonstandard API role setups keep working.
+do $$
+declare p record;
+begin
+  for p in select policyname from pg_policies
+           where schemaname = 'public' and tablename = 'study_time_days'
+  loop
+    execute format('drop policy %I on public.study_time_days', p.policyname);
+  end loop;
+end $$;
 
-drop policy if exists "Clients can update study time rows" on public.study_time_days;
-create policy "Clients can update study time rows"
-  on public.study_time_days
-  for update
-  to anon, authenticated
-  using (true)
-  with check (true);
+create policy "study_time_days_insert" on public.study_time_days
+  for insert to public with check (true);
+
+create policy "study_time_days_update" on public.study_time_days
+  for update to public using (true) with check (true);

--- a/supabase/migrations/20260609000000_study_time_days.sql
+++ b/supabase/migrations/20260609000000_study_time_days.sql
@@ -38,15 +38,23 @@ create index if not exists study_time_days_user_day_idx
 
 alter table public.study_time_days enable row level security;
 
+-- Table-level privileges (RLS still applies on top of these). SELECT is
+-- granted because upserts (INSERT ... ON CONFLICT DO UPDATE) may need to read
+-- conflicting rows, but clients still cannot SELECT data: there is no SELECT
+-- policy, so RLS returns nothing for reads.
+grant select, insert, update on public.study_time_days to anon, authenticated;
+
 -- Same trust model as app_sessions: clients write with the anon key but can
 -- never read usage data back. Developer access goes through the dashboard or
 -- the service role, which bypass RLS.
+drop policy if exists "Clients can insert study time rows" on public.study_time_days;
 create policy "Clients can insert study time rows"
   on public.study_time_days
   for insert
   to anon, authenticated
   with check (true);
 
+drop policy if exists "Clients can update study time rows" on public.study_time_days;
 create policy "Clients can update study time rows"
   on public.study_time_days
   for update

--- a/supabase/migrations/20260609000000_study_time_days.sql
+++ b/supabase/migrations/20260609000000_study_time_days.sql
@@ -1,8 +1,15 @@
 -- Study/app time tracking rollups, pushed by the app for developer analytics.
 --
--- The client upserts ABSOLUTE day totals keyed by (user_id, device_id, day).
--- Values only ever grow on the device, so duplicate or retried requests
--- simply rewrite the same row and can never double count time.
+-- The client calls the upsert_study_time_days() function with ABSOLUTE day
+-- totals keyed by (user_id, device_id, day). Values only ever grow on the
+-- device (and totals are merged with greatest() server-side), so duplicate or
+-- retried requests can never double count time.
+--
+-- Clients have NO direct table access (no grants, RLS enabled, no policies):
+-- the security definer function is the only write path, and nothing can read
+-- the data back except the dashboard / service role.
+--
+-- Safe to re-run: recreates the function and re-applies grants/locks.
 --
 -- Example developer queries:
 --   total in-app hours per day across all users:
@@ -36,19 +43,11 @@ create index if not exists study_time_days_day_idx
 create index if not exists study_time_days_user_day_idx
   on public.study_time_days (user_id, day);
 
+-- Lock the table down completely for client roles. Reads and writes both go
+-- through code that bypasses RLS (the function below / dashboard / service
+-- role), so no client-facing grants or policies are needed at all.
 alter table public.study_time_days enable row level security;
 
--- Table-level privileges (RLS still applies on top of these). SELECT is
--- granted because upserts (INSERT ... ON CONFLICT DO UPDATE) may need to read
--- conflicting rows, but clients still cannot SELECT data: there is no SELECT
--- policy, so RLS returns nothing for reads.
-grant select, insert, update on public.study_time_days to anon, authenticated;
-
--- Same trust model as app_sessions: clients write with the anon key but can
--- never read usage data back. Developer access goes through the dashboard or
--- the service role, which bypass RLS. Policies are recreated from scratch
--- (dropping any leftovers, including restrictive ones) and apply to all
--- roles so nonstandard API role setups keep working.
 do $$
 declare p record;
 begin
@@ -59,8 +58,56 @@ begin
   end loop;
 end $$;
 
-create policy "study_time_days_insert" on public.study_time_days
-  for insert to public with check (true);
+revoke all on public.study_time_days from anon, authenticated;
 
-create policy "study_time_days_update" on public.study_time_days
-  for update to public using (true) with check (true);
+-- The single write path for clients. SECURITY DEFINER runs as the function
+-- owner (table owner), so client roles need no table privileges and RLS does
+-- not apply inside. Totals merge with greatest() so out-of-order or repeated
+-- pushes of absolute values stay monotonic.
+create or replace function public.upsert_study_time_days(rows jsonb)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if rows is null or jsonb_typeof(rows) <> 'array' then
+    raise exception 'rows must be a jsonb array';
+  end if;
+  if jsonb_array_length(rows) > 31 then
+    raise exception 'too many rows in one push';
+  end if;
+
+  insert into public.study_time_days
+    (user_id, device_id, day, activity_ms, study_total_ms, app_total_ms,
+     user_name, user_level, app_version, platform, updated_at)
+  select
+    r->>'user_id',
+    r->>'device_id',
+    (r->>'day')::date,
+    coalesce(r->'activity_ms', '{}'::jsonb),
+    coalesce((r->>'study_total_ms')::bigint, 0),
+    coalesce((r->>'app_total_ms')::bigint, 0),
+    nullif(r->>'user_name', ''),
+    (r->>'user_level')::integer,
+    nullif(r->>'app_version', ''),
+    nullif(r->>'platform', ''),
+    coalesce((r->>'updated_at')::timestamptz, now())
+  from jsonb_array_elements(rows) as r
+  where coalesce(r->>'user_id', '') <> ''
+    and coalesce(r->>'device_id', '') <> ''
+    and (r->>'day') is not null
+  on conflict (user_id, device_id, day) do update set
+    activity_ms = excluded.activity_ms,
+    study_total_ms = greatest(study_time_days.study_total_ms, excluded.study_total_ms),
+    app_total_ms = greatest(study_time_days.app_total_ms, excluded.app_total_ms),
+    user_name = excluded.user_name,
+    user_level = excluded.user_level,
+    app_version = excluded.app_version,
+    platform = excluded.platform,
+    updated_at = excluded.updated_at;
+end;
+$$;
+
+revoke all on function public.upsert_study_time_days(jsonb) from public;
+grant execute on function public.upsert_study_time_days(jsonb) to anon, authenticated;

--- a/supabase/migrations/20260609000000_study_time_days.sql
+++ b/supabase/migrations/20260609000000_study_time_days.sql
@@ -1,0 +1,55 @@
+-- Study/app time tracking rollups, pushed by the app for developer analytics.
+--
+-- The client upserts ABSOLUTE day totals keyed by (user_id, device_id, day).
+-- Values only ever grow on the device, so duplicate or retried requests
+-- simply rewrite the same row and can never double count time.
+--
+-- Example developer queries:
+--   total in-app hours per day across all users:
+--     select day, round(sum(app_total_ms) / 3600000.0, 1) as hours
+--     from public.study_time_days group by day order by day desc;
+--   per-user totals:
+--     select user_id, max(user_name) as user_name,
+--            round(sum(app_total_ms) / 3600000.0, 1) as app_hours,
+--            round(sum(study_total_ms) / 3600000.0, 1) as study_hours
+--     from public.study_time_days group by user_id order by app_hours desc;
+
+create table if not exists public.study_time_days (
+  user_id text not null,
+  device_id text not null,
+  day date not null,
+  -- Per-activity milliseconds, e.g. {"reviews": 1200000, "news": 300000}
+  activity_ms jsonb not null default '{}'::jsonb,
+  study_total_ms bigint not null default 0,
+  app_total_ms bigint not null default 0,
+  user_name text,
+  user_level integer,
+  app_version text,
+  platform text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, device_id, day)
+);
+
+create index if not exists study_time_days_day_idx
+  on public.study_time_days (day);
+create index if not exists study_time_days_user_day_idx
+  on public.study_time_days (user_id, day);
+
+alter table public.study_time_days enable row level security;
+
+-- Same trust model as app_sessions: clients write with the anon key but can
+-- never read usage data back. Developer access goes through the dashboard or
+-- the service role, which bypass RLS.
+create policy "Clients can insert study time rows"
+  on public.study_time_days
+  for insert
+  to anon, authenticated
+  with check (true);
+
+create policy "Clients can update study time rows"
+  on public.study_time_days
+  for update
+  to anon, authenticated
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- Track time spent on reviews, lessons (including Bunpro), extra study sessions, NHK news, songs, the EPUB reader, and video players in a crash-safe local-first MMKV ledger: a 5-second heartbeat folds elapsed time into per-day buckets, so force-quits lose at most a few seconds and nothing is ever double counted; AppState transitions pause the clocks (background time never counts), spans crossing midnight split across days, and clock-jump guards cap implausible deltas.
- Add a Study Time card with a Today/Week/Month/All range selector and bucket chart, available in Analytics and as a configurable home dashboard widget.
- Add a Study Time screen with totals, daily averages, active-day counts, a per-category breakdown, and a tappable day/week/month chart with a toggle to color bars by category; durations animate with an iOS-style rolling digit component built on reanimated, and range switches animate card sizes via layout transitions (respecting reduce motion).
