### PR TITLE
[Fix] Revalidate cached lessons

### DIFF
--- a/app/(app)/lessons.tsx
+++ b/app/(app)/lessons.tsx
@@ -29,6 +29,7 @@ import {
   Subject as ApiSubject,
   getAvailableLessons,
   getAssignmentsOptimized,
+  getLiveLessonAssignmentIds,
   getUserData,
   getStudyMaterials,
   getSubjects,
@@ -51,6 +52,7 @@ import {
   savePersistedLessonSession,
   type PersistedLessonSessionState,
 } from "../../src/utils/lessonSessionPersistence";
+import { revalidatePersistedLessonState } from "../../src/utils/lessonSessionRevalidation";
 import { getRemainingDailyLessonSlots } from "../../src/utils/dailyLessonLimit";
 import { useSubjectColors } from "../../src/utils/subjectColors";
 import { useAuthStore, useSettingsStore } from "../../src/utils/store";
@@ -478,15 +480,53 @@ export default function LessonsScreen() {
           userData?.id ?? null
         );
 
-        if (
-          persistedSession &&
-          restorePersistedLessonSession(
-            persistedSession.state,
-            persistedSession.createdAt
-          )
-        ) {
-          setIsLoading(false);
-          return;
+        if (persistedSession) {
+          let sessionState: PersistedLessonSessionState | null =
+            persistedSession.state;
+
+          // Lessons finished on the WaniKani website (or another client)
+          // since the session was saved must not be shown again on resume.
+          try {
+            const [availableAssignmentIds, pendingProgressIds] =
+              await Promise.all([
+                getLiveLessonAssignmentIds(apiToken),
+                getPendingProgressAssignmentIds().catch(() => ({
+                  lesson: new Set<number>(),
+                  review: new Set<number>(),
+                })),
+              ]);
+
+            const revalidation = revalidatePersistedLessonState(sessionState, {
+              availableAssignmentIds,
+              pendingLessonAssignmentIds: pendingProgressIds.lesson,
+            });
+
+            if (revalidation.removedCount > 0) {
+              console.log(
+                `[Lessons] Removed ${revalidation.removedCount} saved lesson(s) completed outside this session.`
+              );
+            }
+            sessionState = revalidation.state;
+          } catch (revalidationError) {
+            // Offline or API failure: resume the saved session as-is rather
+            // than dropping lessons based on stale cached data.
+            console.warn(
+              "[Lessons] Could not revalidate saved lesson session:",
+              revalidationError
+            );
+          }
+
+          if (!sessionState) {
+            await clearPersistedLessonSession();
+          } else if (
+            restorePersistedLessonSession(
+              sessionState,
+              persistedSession.createdAt
+            )
+          ) {
+            setIsLoading(false);
+            return;
+          }
         }
       }
 

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.79",
+    date: "2026-06-11",
+    changes: [
+      {
+        type: "fix",
+        title: "Resume Lessons Stale Items",
+        description:
+          "Resuming a saved lesson session no longer shows items you already completed on the WaniKani website or another client.",
+      },
+    ],
+  },
+  {
     version: "1.2.78",
     date: "2026-06-11",
     changes: [

--- a/src/utils/__tests__/lessonSessionRevalidation.test.ts
+++ b/src/utils/__tests__/lessonSessionRevalidation.test.ts
@@ -1,0 +1,388 @@
+import type {
+  PersistedLessonItem,
+  PersistedLessonSessionState,
+} from "../lessonSessionPersistence";
+import { revalidatePersistedLessonState } from "../lessonSessionRevalidation";
+
+const makeItem = (
+  id: number,
+  overrides: Partial<PersistedLessonItem> = {}
+): PersistedLessonItem => ({
+  id,
+  assignmentId: 1000 + id,
+  subjectId: 2000 + id,
+  availableAt: null,
+  subject: { object: "kanji", data: {} },
+  meaningDone: false,
+  readingDone: false,
+  meaningIncorrect: 0,
+  readingIncorrect: 0,
+  submitted: false,
+  ...overrides,
+});
+
+const makeState = (
+  batches: { items: PersistedLessonItem[]; completed: boolean }[],
+  overrides: Partial<PersistedLessonSessionState> = {}
+): PersistedLessonSessionState => {
+  const allLessons = batches.flatMap((batch) => batch.items);
+  return {
+    allLessons,
+    lessonBatches: batches,
+    currentBatchIndex: 0,
+    currentItemIndex: 0,
+    mode: "lesson",
+    reviewItems: [],
+    masterQueue: [],
+    activeQueue: [],
+    currentQuestion: null,
+    completedBatchStats: null,
+    isFinalBatchComplete: false,
+    progress: {
+      totalItems: allLessons.length,
+      completedItems: 0,
+      currentBatch: 1,
+      totalBatches: batches.length,
+    },
+    typeCounts: { radical: 0, kanji: allLessons.length, vocabulary: 0 },
+    relatedSubjects: {},
+    ...overrides,
+  };
+};
+
+const availableIdsFor = (items: PersistedLessonItem[]) =>
+  new Set(items.map((item) => item.assignmentId));
+
+describe("revalidatePersistedLessonState", () => {
+  it("returns the state unchanged when every item is still available", () => {
+    const items = [makeItem(0), makeItem(1), makeItem(2)];
+    const state = makeState([{ items, completed: false }]);
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor(items),
+    });
+
+    expect(result.removedCount).toBe(0);
+    expect(result.state).toBe(state);
+  });
+
+  it("clears the session when every unstarted lesson was finished elsewhere", () => {
+    const items = [makeItem(0), makeItem(1)];
+    const state = makeState([{ items, completed: false }]);
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: new Set<number>(),
+    });
+
+    expect(result.removedCount).toBe(2);
+    expect(result.state).toBeNull();
+  });
+
+  it("keeps items completed in-app even when WaniKani no longer lists them", () => {
+    const completedItems = [
+      makeItem(0, { submitted: true, meaningDone: true, readingDone: true }),
+      makeItem(1, { submitted: true, meaningDone: true, readingDone: true }),
+    ];
+    const upcomingItems = [makeItem(2), makeItem(3)];
+    const state = makeState(
+      [
+        { items: completedItems, completed: true },
+        { items: upcomingItems, completed: false },
+      ],
+      { currentBatchIndex: 1 }
+    );
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor(upcomingItems),
+    });
+
+    expect(result.removedCount).toBe(0);
+    expect(result.state).toBe(state);
+  });
+
+  it("keeps items whose completion is queued for offline sync", () => {
+    const items = [makeItem(0), makeItem(1)];
+    const state = makeState([{ items, completed: false }]);
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: new Set([items[1].assignmentId]),
+      pendingLessonAssignmentIds: new Set([items[0].assignmentId]),
+    });
+
+    expect(result.removedCount).toBe(0);
+    expect(result.state).toBe(state);
+  });
+
+  it("reads the submitted flag from reviewItems copies after the JSON round-trip", () => {
+    const batchItem = makeItem(0, { submitted: false });
+    const reviewCopy = makeItem(0, {
+      submitted: true,
+      meaningDone: true,
+      readingDone: true,
+    });
+    const otherItem = makeItem(1);
+    const state = makeState(
+      [{ items: [batchItem, otherItem], completed: false }],
+      { mode: "review", reviewItems: [reviewCopy, makeItem(1)] }
+    );
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: new Set([otherItem.assignmentId]),
+    });
+
+    expect(result.removedCount).toBe(0);
+    expect(result.state).toBe(state);
+  });
+
+  it("drops a lesson finished elsewhere and remaps the current item index", () => {
+    const items = [
+      makeItem(0, { subject: { object: "radical", data: {} } }),
+      makeItem(1),
+      makeItem(2, { subject: { object: "vocabulary", data: {} } }),
+    ];
+    const state = makeState([{ items, completed: false }], {
+      currentItemIndex: 2,
+      typeCounts: { radical: 1, kanji: 1, vocabulary: 1 },
+    });
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor([items[0], items[2]]),
+    });
+
+    expect(result.removedCount).toBe(1);
+    expect(result.state).not.toBeNull();
+    const newState = result.state!;
+    expect(newState.allLessons.map((item) => item.id)).toEqual([0, 2]);
+    expect(newState.lessonBatches[0].items.map((item) => item.id)).toEqual([
+      0, 2,
+    ]);
+    expect(newState.currentItemIndex).toBe(1);
+    expect(newState.progress).toEqual({
+      totalItems: 2,
+      completedItems: 0,
+      currentBatch: 1,
+      totalBatches: 1,
+    });
+    expect(newState.typeCounts).toEqual({
+      radical: 1,
+      kanji: 0,
+      vocabulary: 1,
+    });
+  });
+
+  it("rebuilds review queues without dropped or already-answered questions", () => {
+    const itemDoneMeaning = makeItem(0, { meaningDone: true });
+    const itemFinishedElsewhere = makeItem(1);
+    const itemFresh = makeItem(2);
+    const items = [itemDoneMeaning, itemFinishedElsewhere, itemFresh];
+    const state = makeState([{ items, completed: false }], {
+      mode: "review",
+      reviewItems: items,
+      masterQueue: [
+        { type: "meaning", itemId: 0 },
+        { type: "reading", itemId: 0 },
+        { type: "meaning", itemId: 1 },
+        { type: "reading", itemId: 1 },
+        { type: "meaning", itemId: 2 },
+        { type: "reading", itemId: 2 },
+      ],
+      activeQueue: [
+        { type: "meaning", itemId: 1 },
+        { type: "reading", itemId: 0 },
+        { type: "meaning", itemId: 2 },
+        { type: "reading", itemId: 2 },
+      ],
+      currentQuestion: { type: "meaning", itemId: 1 },
+    });
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor([itemDoneMeaning, itemFresh]),
+    });
+
+    expect(result.removedCount).toBe(1);
+    const newState = result.state!;
+    expect(newState.mode).toBe("review");
+    expect(newState.reviewItems.map((item) => item.id)).toEqual([0, 2]);
+    expect(newState.masterQueue).toEqual([
+      { type: "reading", itemId: 0 },
+      { type: "meaning", itemId: 2 },
+      { type: "reading", itemId: 2 },
+    ]);
+    expect(newState.activeQueue).toEqual(newState.masterQueue);
+    expect(newState.currentQuestion).toEqual({ type: "reading", itemId: 0 });
+  });
+
+  it("keeps the current question when it survives revalidation", () => {
+    const itemFresh = makeItem(0);
+    const itemFinishedElsewhere = makeItem(1);
+    const items = [itemFresh, itemFinishedElsewhere];
+    const state = makeState([{ items, completed: false }], {
+      mode: "review",
+      reviewItems: items,
+      masterQueue: [
+        { type: "meaning", itemId: 0 },
+        { type: "reading", itemId: 0 },
+        { type: "meaning", itemId: 1 },
+        { type: "reading", itemId: 1 },
+      ],
+      activeQueue: [
+        { type: "meaning", itemId: 0 },
+        { type: "reading", itemId: 0 },
+        { type: "meaning", itemId: 1 },
+        { type: "reading", itemId: 1 },
+      ],
+      currentQuestion: { type: "meaning", itemId: 0 },
+    });
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor([itemFresh]),
+    });
+
+    const newState = result.state!;
+    expect(newState.currentQuestion).toEqual({ type: "meaning", itemId: 0 });
+    expect(newState.activeQueue[0]).toEqual({ type: "meaning", itemId: 0 });
+  });
+
+  it("falls back to the next batch in lesson mode when the quiz batch is gone", () => {
+    const doneItems = [
+      makeItem(0, { submitted: true, meaningDone: true, readingDone: true }),
+    ];
+    const quizItems = [makeItem(1), makeItem(2)];
+    const futureItems = [makeItem(3), makeItem(4)];
+    const state = makeState(
+      [
+        { items: doneItems, completed: true },
+        { items: quizItems, completed: false },
+        { items: futureItems, completed: false },
+      ],
+      {
+        currentBatchIndex: 1,
+        mode: "review",
+        reviewItems: quizItems,
+        masterQueue: [
+          { type: "meaning", itemId: 1 },
+          { type: "meaning", itemId: 2 },
+        ],
+        activeQueue: [
+          { type: "meaning", itemId: 1 },
+          { type: "meaning", itemId: 2 },
+        ],
+        currentQuestion: { type: "meaning", itemId: 1 },
+      }
+    );
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor(futureItems),
+    });
+
+    expect(result.removedCount).toBe(2);
+    const newState = result.state!;
+    expect(newState.mode).toBe("lesson");
+    expect(newState.currentBatchIndex).toBe(1);
+    expect(newState.currentItemIndex).toBe(0);
+    expect(newState.lessonBatches).toHaveLength(2);
+    expect(newState.lessonBatches[1].items.map((item) => item.id)).toEqual([
+      3, 4,
+    ]);
+    expect(newState.reviewItems).toEqual([]);
+    expect(newState.activeQueue).toEqual([]);
+    expect(newState.currentQuestion).toBeNull();
+    expect(newState.progress.completedItems).toBe(1);
+  });
+
+  it("marks the quiz batch complete when only in-app-finished items remain", () => {
+    const finishedInApp = makeItem(0, {
+      submitted: true,
+      meaningDone: true,
+      readingDone: true,
+    });
+    const finishedElsewhere = makeItem(1);
+    const futureItems = [makeItem(2)];
+    const state = makeState(
+      [
+        { items: [finishedInApp, finishedElsewhere], completed: false },
+        { items: futureItems, completed: false },
+      ],
+      {
+        mode: "review",
+        reviewItems: [finishedInApp, finishedElsewhere],
+        masterQueue: [
+          { type: "meaning", itemId: 1 },
+          { type: "reading", itemId: 1 },
+        ],
+        activeQueue: [
+          { type: "meaning", itemId: 1 },
+          { type: "reading", itemId: 1 },
+        ],
+        currentQuestion: { type: "meaning", itemId: 1 },
+      }
+    );
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: availableIdsFor(futureItems),
+    });
+
+    expect(result.removedCount).toBe(1);
+    const newState = result.state!;
+    expect(newState.lessonBatches[0].completed).toBe(true);
+    expect(newState.mode).toBe("lesson");
+    expect(newState.currentBatchIndex).toBe(1);
+    expect(newState.progress.completedItems).toBe(1);
+  });
+
+  it("clears the session when the quiz batch is gone and no batches remain", () => {
+    const quizItems = [makeItem(0), makeItem(1)];
+    const state = makeState([{ items: quizItems, completed: false }], {
+      mode: "review",
+      reviewItems: quizItems,
+      masterQueue: [{ type: "meaning", itemId: 0 }],
+      activeQueue: [{ type: "meaning", itemId: 0 }],
+      currentQuestion: { type: "meaning", itemId: 0 },
+    });
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: new Set<number>(),
+    });
+
+    expect(result.state).toBeNull();
+    expect(result.removedCount).toBe(2);
+  });
+
+  it("flips isFinalBatchComplete when remaining batches vanish on the completion screen", () => {
+    const completedItems = [
+      makeItem(0, { submitted: true, meaningDone: true, readingDone: true }),
+    ];
+    const futureItems = [makeItem(1), makeItem(2)];
+    const state = makeState(
+      [
+        { items: completedItems, completed: true },
+        { items: futureItems, completed: false },
+      ],
+      {
+        mode: "batch_complete",
+        isFinalBatchComplete: false,
+        completedBatchStats: {
+          batchNumber: 1,
+          itemCount: 1,
+          typeCounts: { radical: 0, kanji: 1, vocabulary: 0 },
+        },
+      }
+    );
+
+    const result = revalidatePersistedLessonState(state, {
+      availableAssignmentIds: new Set<number>(),
+    });
+
+    expect(result.removedCount).toBe(2);
+    const newState = result.state!;
+    expect(newState.mode).toBe("batch_complete");
+    expect(newState.isFinalBatchComplete).toBe(true);
+    expect(newState.lessonBatches).toHaveLength(1);
+    expect(newState.progress).toEqual({
+      totalItems: 1,
+      completedItems: 1,
+      currentBatch: 1,
+      totalBatches: 1,
+    });
+  });
+});

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3185,6 +3185,23 @@ export async function getAvailableLessons(
 }
 
 /**
+ * Live-only lookup of the assignment IDs currently available for lessons.
+ * Unlike getAvailableLessons this never falls back to cached assignments, so
+ * callers can tell "WaniKani says these lessons are gone" apart from "we are
+ * offline" — it throws when the API can't be reached.
+ */
+export async function getLiveLessonAssignmentIds(
+  apiToken: string
+): Promise<Set<number>> {
+  const initialResponse = await getAssignments(apiToken, {
+    immediately_available_for_lessons: true,
+    burned: false,
+  });
+  const allPages = await fetchAllPages(initialResponse, apiToken);
+  return new Set(allPages.data.map((assignment) => assignment.id));
+}
+
+/**
  * Submit a review to WaniKani (will count towards SRS progression)
  * @param apiToken WaniKani API Token
  * @param assignmentId ID of the assignment being reviewed

--- a/src/utils/lessonSessionRevalidation.ts
+++ b/src/utils/lessonSessionRevalidation.ts
@@ -1,0 +1,273 @@
+import type {
+  PersistedLessonBatch,
+  PersistedLessonItem,
+  PersistedLessonQuestion,
+  PersistedLessonSessionState,
+  PersistedLessonTypeCounts,
+} from "./lessonSessionPersistence";
+
+// Mirrors ACTIVE_QUEUE_SIZE in app/(app)/lessons.tsx.
+const ACTIVE_QUEUE_SIZE = 10;
+
+export interface RevalidateLessonSessionOptions {
+  /** Assignment IDs WaniKani currently reports as available for lessons. */
+  availableAssignmentIds: Set<number>;
+  /** Assignment IDs with locally queued lesson completions awaiting sync. */
+  pendingLessonAssignmentIds?: Set<number>;
+}
+
+export interface RevalidateLessonSessionResult {
+  /** Cleaned state, or null when nothing in the session is left to study. */
+  state: PersistedLessonSessionState | null;
+  /** Lesson items dropped because they were finished outside this session. */
+  removedCount: number;
+}
+
+/**
+ * Drops lesson items from a persisted session that were completed elsewhere
+ * (e.g. on the WaniKani website) since the session was saved. An item is kept
+ * if it was completed in this session, has a completion queued for sync, or is
+ * still in WaniKani's lesson queue.
+ */
+export function revalidatePersistedLessonState(
+  state: PersistedLessonSessionState,
+  options: RevalidateLessonSessionOptions
+): RevalidateLessonSessionResult {
+  const { availableAssignmentIds } = options;
+  const pendingLessonAssignmentIds =
+    options.pendingLessonAssignmentIds ?? new Set<number>();
+
+  // The submitted flag is written to reviewItems copies during a batch quiz,
+  // and the JSON round-trip breaks the object sharing with lessonBatches, so
+  // merge the flag across every copy of an item before deciding its fate.
+  const finishedLocallyIds = new Set<number>();
+  const collectFinished = (item: PersistedLessonItem) => {
+    if (item.submitted === true) {
+      finishedLocallyIds.add(item.id);
+    }
+  };
+  state.allLessons.forEach(collectFinished);
+  state.lessonBatches.forEach((batch) => batch.items.forEach(collectFinished));
+  state.reviewItems.forEach(collectFinished);
+
+  const shouldKeepItem = (item: PersistedLessonItem) =>
+    finishedLocallyIds.has(item.id) ||
+    availableAssignmentIds.has(item.assignmentId) ||
+    pendingLessonAssignmentIds.has(item.assignmentId);
+
+  const keptItemIds = new Set<number>();
+  state.allLessons.forEach((item) => {
+    if (shouldKeepItem(item)) {
+      keptItemIds.add(item.id);
+    }
+  });
+
+  const removedCount = state.allLessons.length - keptItemIds.size;
+  if (removedCount === 0) {
+    return { state, removedCount: 0 };
+  }
+
+  const allLessons = state.allLessons.filter((item) =>
+    keptItemIds.has(item.id)
+  );
+  if (allLessons.length === 0) {
+    return { state: null, removedCount };
+  }
+
+  const newBatches: PersistedLessonBatch[] = [];
+  let currentBatchSurvived = false;
+  let currentBatchIndex = 0;
+  let currentItemIndex = 0;
+  let survivingBatchesBeforeCurrent = 0;
+
+  state.lessonBatches.forEach((batch, batchIndex) => {
+    const items = batch.items.filter((item) => keptItemIds.has(item.id));
+    if (items.length === 0) {
+      return;
+    }
+
+    if (batchIndex < state.currentBatchIndex) {
+      survivingBatchesBeforeCurrent += 1;
+    }
+
+    if (batchIndex === state.currentBatchIndex) {
+      currentBatchSurvived = true;
+      currentBatchIndex = newBatches.length;
+      const removedBeforeCurrentItem = batch.items
+        .slice(0, state.currentItemIndex)
+        .filter((item) => !keptItemIds.has(item.id)).length;
+      currentItemIndex = Math.min(
+        Math.max(state.currentItemIndex - removedBeforeCurrentItem, 0),
+        items.length - 1
+      );
+    }
+
+    newBatches.push({ items, completed: batch.completed });
+  });
+
+  if (newBatches.length === 0) {
+    return { state: null, removedCount };
+  }
+
+  if (!currentBatchSurvived) {
+    // Index of the first surviving batch after the dropped current one (may
+    // equal newBatches.length when the current batch was the last).
+    currentBatchIndex = survivingBatchesBeforeCurrent;
+  }
+
+  const findUncompletedBatchIndex = (fromIndex: number) => {
+    for (
+      let index = Math.max(fromIndex, 0);
+      index < newBatches.length;
+      index += 1
+    ) {
+      if (!newBatches[index].completed) {
+        return index;
+      }
+    }
+    return -1;
+  };
+
+  let mode = state.mode;
+  let reviewItems = state.reviewItems.filter((item) =>
+    keptItemIds.has(item.id)
+  );
+  let masterQueue = state.masterQueue.filter((question) =>
+    keptItemIds.has(question.itemId)
+  );
+  let activeQueue = state.activeQueue.filter((question) =>
+    keptItemIds.has(question.itemId)
+  );
+  let currentQuestion =
+    state.currentQuestion && keptItemIds.has(state.currentQuestion.itemId)
+      ? state.currentQuestion
+      : null;
+  let completedBatchStats = state.completedBatchStats;
+  let isFinalBatchComplete = state.isFinalBatchComplete;
+
+  const advanceToLessonBatch = (index: number) => {
+    mode = "lesson";
+    currentBatchIndex = index;
+    currentItemIndex = 0;
+    reviewItems = [];
+    masterQueue = [];
+    activeQueue = [];
+    currentQuestion = null;
+    completedBatchStats = null;
+    isFinalBatchComplete = false;
+  };
+
+  if (mode === "review" && currentBatchSurvived) {
+    const reviewItemById = new Map(reviewItems.map((item) => [item.id, item]));
+    const isOutstanding = (question: PersistedLessonQuestion) => {
+      const item = reviewItemById.get(question.itemId);
+      if (!item) {
+        return false;
+      }
+      return question.type === "meaning" ? !item.meaningDone : !item.readingDone;
+    };
+
+    // Rebuild the queues the same way a fresh quiz initializes them: the
+    // master queue holds every outstanding question with the active window at
+    // its head, which keeps the refill/completion length checks valid.
+    const seenQuestions = new Set<string>();
+    const outstanding: PersistedLessonQuestion[] = [];
+    [...state.activeQueue, ...state.masterQueue].forEach((question) => {
+      const key = `${question.itemId}:${question.type}`;
+      if (seenQuestions.has(key) || !isOutstanding(question)) {
+        return;
+      }
+      seenQuestions.add(key);
+      outstanding.push(question);
+    });
+
+    if (outstanding.length === 0) {
+      // Every remaining quiz item was already completed in-app; treat the
+      // batch as done and move on to the next one.
+      newBatches[currentBatchIndex] = {
+        ...newBatches[currentBatchIndex],
+        completed: true,
+      };
+      const nextIndex = findUncompletedBatchIndex(currentBatchIndex + 1);
+      if (nextIndex === -1) {
+        return { state: null, removedCount };
+      }
+      advanceToLessonBatch(nextIndex);
+    } else {
+      masterQueue = outstanding;
+      activeQueue = outstanding.slice(0, ACTIVE_QUEUE_SIZE);
+      currentQuestion = activeQueue[0] ?? null;
+    }
+  } else if (!currentBatchSurvived) {
+    const nextIndex = findUncompletedBatchIndex(currentBatchIndex);
+    if (nextIndex === -1) {
+      return { state: null, removedCount };
+    }
+    advanceToLessonBatch(nextIndex);
+  } else if (mode === "batch_complete") {
+    isFinalBatchComplete =
+      findUncompletedBatchIndex(currentBatchIndex + 1) === -1;
+  }
+
+  const completedItems = newBatches.reduce(
+    (sum, batch) => (batch.completed ? sum + batch.items.length : sum),
+    0
+  );
+
+  const typeCounts: PersistedLessonTypeCounts = {
+    radical: 0,
+    kanji: 0,
+    vocabulary: 0,
+  };
+  newBatches.forEach((batch) => {
+    if (batch.completed) {
+      return;
+    }
+    batch.items.forEach((item) => {
+      const subjectType = item.subject?.object;
+      if (subjectType === "radical") {
+        typeCounts.radical += 1;
+      } else if (subjectType === "kanji") {
+        typeCounts.kanji += 1;
+      } else if (
+        subjectType === "vocabulary" ||
+        subjectType === "kana_vocabulary"
+      ) {
+        typeCounts.vocabulary += 1;
+      }
+    });
+  });
+
+  const totalBatches = newBatches.length;
+  const currentBatchNumber =
+    mode === "batch_complete"
+      ? isFinalBatchComplete
+        ? totalBatches
+        : Math.min(currentBatchIndex + 2, totalBatches)
+      : currentBatchIndex + 1;
+
+  return {
+    removedCount,
+    state: {
+      allLessons,
+      lessonBatches: newBatches,
+      currentBatchIndex,
+      currentItemIndex,
+      mode,
+      reviewItems,
+      masterQueue,
+      activeQueue,
+      currentQuestion,
+      completedBatchStats,
+      isFinalBatchComplete,
+      progress: {
+        totalItems: allLessons.length,
+        completedItems,
+        currentBatch: currentBatchNumber,
+        totalBatches,
+      },
+      typeCounts,
+      relatedSubjects: state.relatedSubjects,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Cached lessons weren't revalidated, so if you do lessons that are cached in some other device/app then the cache will show stale lessons. This PR fixes it