### PR TITLE
[Fix] Restore review Wrap Up toggle

### DIFF
--- a/app/(app)/custom-review.tsx
+++ b/app/(app)/custom-review.tsx
@@ -1,6 +1,6 @@
 import { router, useLocalSearchParams } from "expo-router";
 import { useActivityTracking } from "../../src/hooks/useActivityTracking";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     ActivityIndicator,
     Alert,
@@ -76,6 +76,7 @@ interface CustomReviewSavedSession {
   currentQuestion: ReviewQueueQuestion | null;
   progress: CustomReviewProgressState;
   isWrapUpMode: boolean;
+  wrapUpDeferredQuestions?: ReviewQueueQuestion[];
   sessionUsesAnkiGrouping: boolean;
   studyMaterialEntries: [number, { meaning_synonyms?: string[] }][];
 }
@@ -127,6 +128,7 @@ export default function CustomReviewScreen() {
   const [hasError, setHasError] = useState(false);
   // Wrap up mode state
   const [isWrapUpMode, setIsWrapUpMode] = useState(false);
+  const wrapUpDeferredQuestionsRef = useRef<ReviewQueueQuestion[]>([]);
   const [studyMaterialsMap, setStudyMaterialsMap] = useState<Map<number, { meaning_synonyms?: string[] }>>(new Map());
   const [sessionUsesAnkiGrouping, setSessionUsesAnkiGrouping] = useState(
     effectiveAnkiGrouping,
@@ -242,6 +244,17 @@ export default function CustomReviewScreen() {
             typeof entry[1] === "object",
         )
       : [];
+    const restoredWrapUpDeferredQuestions = Array.isArray(
+      savedSession.wrapUpDeferredQuestions,
+    )
+      ? savedSession.wrapUpDeferredQuestions.filter(
+          (question): question is ReviewQueueQuestion =>
+            !!question &&
+            typeof question === "object" &&
+            typeof question.itemId === "number" &&
+            (question.type === "meaning" || question.type === "reading"),
+        )
+      : [];
 
     setReviewItems(savedSession.reviewItems as ReviewItem[]);
     setActiveQueue(restoredQueue);
@@ -251,6 +264,8 @@ export default function CustomReviewScreen() {
       ...(savedSession.progress || {}),
     });
     setIsWrapUpMode(savedSession.isWrapUpMode === true);
+    wrapUpDeferredQuestionsRef.current =
+      savedSession.isWrapUpMode === true ? restoredWrapUpDeferredQuestions : [];
     setStudyMaterialsMap(new Map(normalizedStudyMaterialEntries));
     setSessionUsesAnkiGrouping(
       typeof savedSession.sessionUsesAnkiGrouping === "boolean"
@@ -275,6 +290,7 @@ export default function CustomReviewScreen() {
       currentQuestion,
       progress,
       isWrapUpMode,
+      wrapUpDeferredQuestions: wrapUpDeferredQuestionsRef.current,
       sessionUsesAnkiGrouping,
       studyMaterialEntries: Array.from(studyMaterialsMap.entries()),
     };
@@ -312,6 +328,7 @@ export default function CustomReviewScreen() {
       setHasError(false);
       setIsFinished(false);
       setIsWrapUpMode(false);
+      wrapUpDeferredQuestionsRef.current = [];
       setSessionUsesAnkiGrouping(effectiveAnkiGrouping);
       await clearSavedCustomReviewSession();
 
@@ -500,9 +517,33 @@ export default function CustomReviewScreen() {
     loadCustomReview();
   }, [loadCustomReview]);
 
-  // Wrap up: restrict remaining queue to exactly WRAP_UP_TARGET_SUBJECTS subjects
+  // Wrap up: toggle between the trimmed queue and the full remaining queue.
   const handleWrapUp = useCallback(() => {
-    if (isWrapUpMode) return;
+    if (isWrapUpMode) {
+      const remainingInActive = currentQuestion
+        ? activeQueue.slice(1)
+        : activeQueue.slice();
+      const restoredQueue = currentQuestion
+        ? [
+            currentQuestion,
+            ...remainingInActive,
+            ...wrapUpDeferredQuestionsRef.current,
+          ]
+        : [...remainingInActive, ...wrapUpDeferredQuestionsRef.current];
+
+      wrapUpDeferredQuestionsRef.current = [];
+      setIsWrapUpMode(false);
+      setActiveQueue(restoredQueue);
+
+      if (restoredQueue.length > 0) {
+        setCurrentQuestion(restoredQueue[0]);
+        setIsFinished(false);
+      } else {
+        setCurrentQuestion(null);
+        setIsFinished(true);
+      }
+      return;
+    }
 
     setIsWrapUpMode(true);
 
@@ -568,6 +609,9 @@ export default function CustomReviewScreen() {
 
     // Filter remaining questions to only selected subjects
     const filteredRemaining = questionsAfterCurrent.filter(q => targetSubjectIds.includes(q.itemId));
+    wrapUpDeferredQuestionsRef.current = questionsAfterCurrent.filter(
+      q => !targetSubjectIds.includes(q.itemId)
+    );
 
     // Rebuild active queue: keep current question, then filtered remainder
     const newActive = currentQuestion ? [currentQuestion, ...filteredRemaining] : filteredRemaining;

--- a/app/(app)/recent-lessons-review.tsx
+++ b/app/(app)/recent-lessons-review.tsx
@@ -1,6 +1,6 @@
 import { router, useLocalSearchParams } from "expo-router";
 import { useActivityTracking } from "../../src/hooks/useActivityTracking";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Alert, StyleSheet, Text, View } from "react-native";
 import RecentLessonsResultsScreen from "../../src/components/RecentLessonsResultsScreen";
 import ReviewQuestionScreen from "../../src/components/ReviewQuestionScreen";
@@ -83,6 +83,7 @@ export default function RecentLessonsReview() {
 
   // Wrap up mode state
   const [isWrapUpMode, setIsWrapUpMode] = useState(false);
+  const wrapUpDeferredQuestionsRef = useRef<Question[]>([]);
   const [studyMaterialsMap, setStudyMaterialsMap] = useState<Map<number, { meaning_synonyms?: string[] }>>(new Map());
 
   // Handler for when a synonym is added from the review screen
@@ -139,9 +140,21 @@ export default function RecentLessonsReview() {
     return questions;
   }, [effectiveAnkiGrouping, reviewQuestionOrderEnabled, preferredQuestionType]);
 
-  // Wrap up mode: reorder remaining questions to complete exactly WRAP_UP_TARGET_SUBJECTS more subjects
+  // Wrap up mode: toggle between the trimmed queue and the full remaining queue.
   const handleWrapUp = useCallback(() => {
-    if (isWrapUpMode) return; // Already in wrap up mode
+    if (isWrapUpMode) {
+      const splitIndex = Math.min(currentQuestionIndex + 1, questions.length);
+      const restoredQuestions = [
+        ...questions.slice(0, splitIndex),
+        ...questions.slice(splitIndex),
+        ...wrapUpDeferredQuestionsRef.current,
+      ];
+
+      wrapUpDeferredQuestionsRef.current = [];
+      setIsWrapUpMode(false);
+      setQuestions(restoredQuestions);
+      return;
+    }
 
     console.log("[Recent Lessons Wrap Up] Activating wrap up mode");
     setIsWrapUpMode(true);
@@ -222,6 +235,9 @@ export default function RecentLessonsReview() {
     // Filter remaining questions to only include those belonging to the target subjects
     const filteredRemaining = questionsAfterCurrent.filter((q) =>
       targetSubjectIds.includes(q.itemId)
+    );
+    wrapUpDeferredQuestionsRef.current = questionsAfterCurrent.filter(
+      (q) => !targetSubjectIds.includes(q.itemId)
     );
 
     console.log(
@@ -407,6 +423,7 @@ export default function RecentLessonsReview() {
       setIncorrectAnswers(initialIncorrect);
       setAllCompleted(false);
       setIsWrapUpMode(false);
+      wrapUpDeferredQuestionsRef.current = [];
 
       // Mark as successfully loaded
       setLoadedWindow(recentLessonsWindow);

--- a/app/(app)/reviews.tsx
+++ b/app/(app)/reviews.tsx
@@ -117,6 +117,7 @@ export default function ReviewScreen() {
   const pendingSubmissionCountRef = useRef(0);
   const hasShownReviewPermissionWarningRef = useRef(false);
   const skippedItemIdsRef = useRef<number[]>([]);
+  const wrapUpDeferredQuestionsRef = useRef<ReviewQueueQuestion[]>([]);
   const {
     ankiCardMode,
     ankiGroupQuestions,
@@ -425,6 +426,8 @@ export default function ReviewScreen() {
       pendingSubmissionCountRef.current = 0;
       hasShownReviewPermissionWarningRef.current = false;
       skippedItemIdsRef.current = [];
+      wrapUpDeferredQuestionsRef.current = [];
+      setIsWrapUpMode(false);
       setFailedSubmissions([]);
       setSubmittingResults(false);
       setReviewPermissionWarning(null);
@@ -802,9 +805,30 @@ export default function ReviewScreen() {
     }
   }, [apiToken, isAuthLoading, reviewOrder, reviewTypeOrderEnabled, reviewTypeOrder, prioritizeCriticalItems, acceptUserSynonymsAsAnswers, showAnswerStopSubjectDetails, backToBackQuestions, reviewQuestionOrderEnabled, preferredQuestionType, effectiveAnkiGrouping, reviewBatchSizeEnabled, reviewBatchSize, REVIEW_MAX_QUESTION_GAP]);
 
-  // Wrap up mode: reorder queue to complete exactly WRAP_UP_TARGET_SUBJECTS more subjects
+  // Wrap up mode: toggle between the trimmed wrap-up queue and the full pool.
   const handleWrapUp = useCallback(() => {
-    if (isWrapUpMode) return; // Already in wrap up mode
+    if (isWrapUpMode) {
+      const remainingInActive = currentQuestion
+        ? activeQueue.slice(1)
+        : activeQueue.slice();
+      const restoredQuestions = [
+        ...remainingInActive,
+        ...masterQueue,
+        ...wrapUpDeferredQuestionsRef.current,
+      ];
+      const restoredActiveQueue = currentQuestion
+        ? [currentQuestion, ...restoredQuestions.slice(0, ACTIVE_QUEUE_SIZE - 1)]
+        : restoredQuestions.slice(0, ACTIVE_QUEUE_SIZE);
+      const restoredMasterQueue = restoredQuestions.slice(
+        currentQuestion ? ACTIVE_QUEUE_SIZE - 1 : ACTIVE_QUEUE_SIZE
+      );
+
+      wrapUpDeferredQuestionsRef.current = [];
+      setIsWrapUpMode(false);
+      setActiveQueue(restoredActiveQueue);
+      setMasterQueue(restoredMasterQueue);
+      return;
+    }
 
     setIsWrapUpMode(true);
     
@@ -871,6 +895,9 @@ export default function ReviewScreen() {
 
     // Filter remaining questions to only include those belonging to the target subjects
     const filteredRemainingQuestions = questionsAfterCurrent.filter(q => targetSubjectIds.includes(q.itemId));
+    wrapUpDeferredQuestionsRef.current = questionsAfterCurrent.filter(
+      q => !targetSubjectIds.includes(q.itemId)
+    );
 
     // Rebuild the queues: keep current question, then only filtered remaining
     const newActiveQueue = currentQuestion

--- a/app/__tests__/CustomReview.test.tsx
+++ b/app/__tests__/CustomReview.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import CustomReviewScreen from '../(app)/custom-review';
+import {
+  getAllAssignmentsCached,
+  getStudyMaterials,
+  getSubjects,
+} from '../../src/utils/api';
+import { getAllSubjects } from '../../src/utils/cache';
+import { useAuthStore, useSettingsStore } from '../../src/utils/store';
+
+const mockUseLocalSearchParams = jest.fn();
+
+jest.mock('expo-router', () => ({
+  router: {
+    replace: jest.fn(),
+    back: jest.fn(),
+    dismissAll: jest.fn(),
+  },
+  useLocalSearchParams: () => mockUseLocalSearchParams(),
+}));
+
+jest.mock('../../src/utils/api', () => ({
+  getAllAssignmentsCached: jest.fn(),
+  getSubjects: jest.fn(),
+  getStudyMaterials: jest.fn(),
+}));
+
+jest.mock('../../src/utils/cache', () => ({
+  getAllSubjects: jest.fn(),
+}));
+
+jest.mock('../../src/utils/extraStudySessionPersistence', () => ({
+  EXTRA_STUDY_SESSION_STORAGE_KEYS: {
+    CUSTOM_REVIEW: 'extra_study_session:custom_review',
+  },
+  clearExtraStudySessionState: jest.fn().mockResolvedValue(undefined),
+  loadExtraStudySessionState: jest.fn().mockResolvedValue(null),
+  saveExtraStudySessionState: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../src/utils/store', () => ({
+  useAuthStore: jest.fn(),
+  useSettingsStore: jest.fn(),
+}));
+
+jest.mock('../../src/utils/theme', () => ({
+  useTheme: jest.fn(() => ({
+    theme: {
+      backgroundColor: '#ffffff',
+      border: '#dddddd',
+      isDark: false,
+      primary: '#7c3aed',
+      secondary: '#7c3aed',
+      textColor: '#111111',
+      textLight: '#999999',
+      textSecondary: '#555555',
+    },
+  })),
+}));
+
+jest.mock('../../src/components/ReviewResultsScreen', () => {
+  const React = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+
+  return function MockReviewResultsScreen() {
+    return <Text>Custom review results</Text>;
+  };
+});
+
+jest.mock('../../src/components/ReviewQuestionScreen', () => {
+  const React = jest.requireActual('react');
+  const { Text, TouchableOpacity, View } = jest.requireActual('react-native');
+
+  return function MockReviewQuestionScreen({
+    isWrapUpAvailable,
+    isWrapUpMode,
+    remainingSubjectsCount,
+    onWrapUp,
+  }: {
+    isWrapUpAvailable?: boolean;
+    isWrapUpMode?: boolean;
+    remainingSubjectsCount?: number;
+    onWrapUp?: () => void;
+  }) {
+    return (
+      <View>
+        {isWrapUpMode ? (
+          <TouchableOpacity onPress={onWrapUp}>
+            <Text>Wrapping Up ({remainingSubjectsCount} left)</Text>
+          </TouchableOpacity>
+        ) : isWrapUpAvailable ? (
+          <TouchableOpacity onPress={onWrapUp}>
+            <Text>Wrap Up ({remainingSubjectsCount} left)</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    );
+  };
+});
+
+describe('CustomReview Screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({
+      apiToken: 'test-token',
+    });
+
+    (useSettingsStore as unknown as jest.Mock).mockReturnValue({
+      ankiCardMode: false,
+      ankiGroupQuestions: false,
+      ankiCardModeScope: 'both',
+      acceptUserSynonymsAsAnswers: false,
+      customReviewOrder: 'lowestLevelFirst',
+      backToBackQuestions: false,
+      reviewQuestionOrderEnabled: false,
+      meaningFirst: true,
+    });
+
+    (getStudyMaterials as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+    (getSubjects as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+  });
+
+  it('should toggle custom review wrap up back to the full queue', async () => {
+    const subjects = Array.from({ length: 12 }, (_, index) => ({
+      id: 1001 + index,
+      object: 'kanji',
+      data: {
+        characters: `漢${index}`,
+        level: 1,
+        meanings: [
+          { meaning: `Chinese ${index}`, primary: true },
+        ],
+        readings: [
+          { reading: 'かん', primary: true },
+        ],
+        character_images: [],
+        pronunciation_audios: [],
+      },
+    }));
+    const assignments = subjects.map((subject, index) => ({
+      id: 123 + index,
+      data: {
+        subject_id: subject.id,
+        subject_type: 'kanji',
+        srs_stage: 1,
+        available_at: null,
+      },
+    }));
+
+    mockUseLocalSearchParams.mockReturnValue({
+      subjectIds: subjects.map((subject) => subject.id).join(','),
+      resume: 'false',
+    });
+    (getAllSubjects as jest.Mock).mockResolvedValue(subjects);
+    (getAllAssignmentsCached as jest.Mock).mockResolvedValue({
+      data: assignments,
+    });
+
+    const { getByText } = render(<CustomReviewScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Wrap Up (12 left)')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Wrap Up (12 left)'));
+
+    await waitFor(() => {
+      expect(getByText('Wrapping Up (10 left)')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Wrapping Up (10 left)'));
+
+    await waitFor(() => {
+      expect(getByText('Wrap Up (12 left)')).toBeTruthy();
+    });
+  });
+});

--- a/app/__tests__/RecentLessonsReview.test.tsx
+++ b/app/__tests__/RecentLessonsReview.test.tsx
@@ -54,6 +54,10 @@ jest.mock('../../src/components/ReviewQuestionScreen', () => {
   return function MockReviewQuestionScreen({
     item,
     questionType,
+    isWrapUpAvailable,
+    isWrapUpMode,
+    remainingSubjectsCount,
+    onWrapUp,
   }: {
     item: {
       subject: {
@@ -65,9 +69,13 @@ jest.mock('../../src/components/ReviewQuestionScreen', () => {
       };
     };
     questionType: 'meaning' | 'reading';
+    isWrapUpAvailable?: boolean;
+    isWrapUpMode?: boolean;
+    remainingSubjectsCount?: number;
+    onWrapUp?: () => void;
   }) {
     const [answer, setAnswer] = React.useState('');
-    const [feedback, setFeedback] = React.useState<'correct' | 'incorrect' | null>(null);
+    const [feedback, setFeedback] = React.useState(null);
     const correctAnswer =
       item.subject.data.meanings.find((meaning) => meaning.primary)?.meaning ||
       item.subject.data.meanings[0]?.meaning ||
@@ -102,6 +110,15 @@ jest.mock('../../src/components/ReviewQuestionScreen', () => {
             <Text>{correctAnswer}</Text>
           </View>
         ) : null}
+        {isWrapUpMode ? (
+          <TouchableOpacity onPress={onWrapUp}>
+            <Text>Wrapping Up ({remainingSubjectsCount} left)</Text>
+          </TouchableOpacity>
+        ) : isWrapUpAvailable ? (
+          <TouchableOpacity onPress={onWrapUp}>
+            <Text>Wrap Up ({remainingSubjectsCount} left)</Text>
+          </TouchableOpacity>
+        ) : null}
       </View>
     );
   };
@@ -117,31 +134,31 @@ jest.mock('../../src/components/RecentLessonsResultsScreen', () => {
 });
 
 jest.mock('../../src/utils/reviewUtils', () => ({
-  prepareReviewData: jest.fn((subjects, assignments) => {
-    // Simple mock implementation that returns a formatted review item
-    return [
-      {
-        id: 0,
-        subjectId: 1001,
-        assignmentId: 123,
-        characters: '漢',
-        meanings: [
-          { meaning: 'Chinese', primary: true },
-        ],
-        readings: [
-          { reading: 'かん', primary: true },
-        ],
-        type: 'kanji',
-        meaningQuestion: {
-          type: 'meaning',
-          itemId: 0,
-        },
-        readingQuestion: {
-          type: 'reading',
-          itemId: 0,
-        }
-      }
-    ];
+  prepareReviewData: jest.fn((subjects: any[], assignments: any[]) => {
+    // Simple mock implementation that returns formatted review items.
+    return subjects.map((subject, index) => ({
+      id: index,
+      subjectId: subject.id,
+      assignmentId: assignments[index]?.id ?? index,
+      characters: subject.data.characters,
+      meanings: subject.data.meanings,
+      readings: subject.data.readings,
+      characterImages: subject.data.character_images,
+      pronunciationAudios: subject.data.pronunciation_audios,
+      type: subject.object,
+      srsStage: assignments[index]?.srs_stage,
+      meaningQuestion: {
+        type: 'meaning',
+        itemId: index,
+      },
+      readingQuestion:
+        Array.isArray(subject.data.readings) && subject.data.readings.length > 0
+          ? {
+              type: 'reading',
+              itemId: index,
+            }
+          : null,
+    }));
   }),
   shuffleArray: jest.fn(arr => arr), // Return array unchanged for predictability
 }));
@@ -164,7 +181,7 @@ describe('RecentLessonsReview Screen', () => {
     jest.clearAllMocks();
     
     // Setup auth store mock
-    (useAuthStore as jest.Mock).mockReturnValue({
+    (useAuthStore as unknown as jest.Mock).mockReturnValue({
       apiToken: 'test-token',
     });
 
@@ -277,6 +294,62 @@ describe('RecentLessonsReview Screen', () => {
       expect(getByText('Incorrect - Next')).toBeTruthy();
       expect(getByText('Correct answer:')).toBeTruthy();
       expect(getByText('Chinese')).toBeTruthy();
+    });
+  });
+
+  it('should toggle recent lesson wrap up back to the full queue', async () => {
+    const subjects = Array.from({ length: 12 }, (_, index) => ({
+      id: 1001 + index,
+      object: 'kanji',
+      data: {
+        characters: `漢${index}`,
+        level: 1,
+        meanings: [
+          { meaning: `Chinese ${index}`, primary: true },
+        ],
+        readings: [
+          { reading: 'かん', primary: true },
+        ],
+        character_images: [],
+        pronunciation_audios: [],
+      },
+    }));
+    const assignments = subjects.map((subject, index) => ({
+      id: 123 + index,
+      data: {
+        subject_id: subject.id,
+        subject_type: 'kanji',
+        srs_stage: 1,
+        started_at: new Date().toISOString(),
+        burned_at: null,
+        passed_at: null,
+      },
+    }));
+
+    (useDashboardData as jest.Mock).mockReturnValue({
+      isLoading: false,
+      dashboardData: {
+        assignments,
+        subjects,
+      },
+    });
+
+    const { getByText } = render(<RecentLessonsReview />);
+
+    await waitFor(() => {
+      expect(getByText('Wrap Up (12 left)')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Wrap Up (12 left)'));
+
+    await waitFor(() => {
+      expect(getByText('Wrapping Up (10 left)')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Wrapping Up (10 left)'));
+
+    await waitFor(() => {
+      expect(getByText('Wrap Up (12 left)')).toBeTruthy();
     });
   });
 });

--- a/src/components/ReviewQuestionScreen.tsx
+++ b/src/components/ReviewQuestionScreen.tsx
@@ -1464,6 +1464,8 @@ export default function ReviewQuestionScreen({
     hasContextHint && (contextHintDisplayMode === "visible" || showContextHint);
   const shouldShowReviewItemMetadataInLayout =
     shouldShowReviewItemMetadata && !isContextHintVisible;
+  const shouldShowAnkiReviewItemMetadata =
+    effectiveAnkiCardMode && shouldShowReviewItemMetadata;
   const contextHintPanelHeight = useMemo(() => {
     const keyboardVisible = iosKeyboardVisible || androidKeyboardHeight > 0;
     const viewportCap = Math.round(windowHeight * (keyboardVisible ? 0.13 : 0.14));
@@ -4831,7 +4833,7 @@ export default function ReviewQuestionScreen({
     isCurrentQuestionAnkiRevealed &&
     !effectiveAnkiButtonlessMode;
   const ankiPreCardOverlayJustification =
-    shouldShowReviewItemMetadataInLayout && showAnkiSkipChip
+    shouldShowAnkiReviewItemMetadata && showAnkiSkipChip
       ? "space-between"
       : showAnkiSkipChip
         ? "flex-end"
@@ -5362,14 +5364,14 @@ export default function ReviewQuestionScreen({
             >
             {((shouldShowSrsProgressionCard && !shouldUseCompactSrsProgressionCard) ||
               showAnkiSkipChip ||
-              shouldShowReviewItemMetadataInLayout) && (
+              shouldShowAnkiReviewItemMetadata) && (
               <View
                 style={[
                   styles.ankiPreCardOverlayRow,
                   { justifyContent: ankiPreCardOverlayJustification },
                 ]}
               >
-                {shouldShowReviewItemMetadataInLayout && renderReviewMetadata(true)}
+                {shouldShowAnkiReviewItemMetadata && renderReviewMetadata(true)}
                 {showAnkiSkipChip && (
                   <TouchableOpacity
                     style={[

--- a/src/components/ReviewQuestionScreen.tsx
+++ b/src/components/ReviewQuestionScreen.tsx
@@ -4251,7 +4251,7 @@ export default function ReviewQuestionScreen({
     jitaiEnabled && !overridePromptText && Boolean(subject.data.characters);
   const showReviewSearchButton = reviewSearchButtonEnabled && !isLessonFlow;
   const showWrapUpButton = isWrapUpAvailable && !isLessonFlow && !isWrapUpMode;
-  const showWrapUpIndicator = isWrapUpMode;
+  const showWrapUpIndicator = isWrapUpMode && !isLessonFlow;
   const hasFloatingWrapUpPill = showWrapUpButton || showWrapUpIndicator;
   const floatingToolButtonsTop = hasFloatingWrapUpPill
     ? FLOATING_REVIEW_TOOL_BUTTON_TOP_WITH_WRAP_UP
@@ -5022,15 +5022,22 @@ export default function ReviewQuestionScreen({
         </TouchableOpacity>
       )}
 
-      {/* Floating Wrap Up Mode Indicator */}
+      {/* Floating Wrap Up Mode Toggle */}
       {showWrapUpIndicator && (
-        <View style={styles.floatingWrapUpIndicator}>
+        <TouchableOpacity
+          style={styles.floatingWrapUpIndicator}
+          onPress={onWrapUp}
+          disabled={!onWrapUp}
+          activeOpacity={0.75}
+          accessibilityRole="button"
+          accessibilityLabel={`Exit wrap up mode. ${remainingSubjectsCount} subjects remaining.`}
+        >
           <View style={styles.floatingWrapUpIndicatorInner} />
           <Ionicons name="flag" size={18} color="#ffd700" />
           <Text style={styles.floatingWrapUpIndicatorText}>
             Wrapping Up ({remainingSubjectsCount} left)
           </Text>
-        </View>
+        </TouchableOpacity>
       )}
 
       {skipCueText && (

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.81",
+    date: "2026-06-17",
+    changes: [
+      {
+        type: "fix",
+        title: "Review Wrap Up Toggle",
+        description:
+          "Fixed Wrap Up in reviews, custom reviews, and recent lesson reviews so tapping the wrapping-up pill restores the full remaining queue.",
+      },
+    ],
+  },
+  {
     version: "1.2.80",
     date: "2026-06-15",
     changes: [


### PR DESCRIPTION
## Summary
- Restores Wrap Up toggling in normal reviews so tapping the wrapping-up pill brings back the full remaining queue.
- Applies the same restore behavior to custom reviews and recent lesson reviews.
- Makes the wrapping-up pill an interactive exit toggle in the shared review question UI.
- Persists deferred Wrap Up questions for custom review sessions saved with Continue Later.

