### PR TITLE
[Fix] WaniKani Mnemonic Tags

### DIFF
--- a/src/components/KanjiDetails.tsx
+++ b/src/components/KanjiDetails.tsx
@@ -32,6 +32,7 @@ import {
 } from "../utils/subjectColors";
 import { useSettingsStore } from "../utils/store";
 import { useTheme } from "../utils/theme";
+import { tokenizeWaniKaniMnemonic } from "../utils/wanikaniMnemonic";
 import { CopyTooltip, useCopyTooltip } from "./CopyTooltip";
 import KanjiPracticeModal from "./KanjiPracticeModal";
 import PitchAccentVisualization from "./PitchAccentVisualization";
@@ -469,83 +470,62 @@ export default function KanjiDetails({
   const formatMnemonic = (mnemonic: string) => {
     if (!mnemonic) return null;
 
-    // Replace HTML entities
-    let processedText = mnemonic.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
-    // Strip <ja> tags (open/self-closing and closing) entirely
-    processedText = processedText
-      .replace(/<ja\s*\/?>/g, "")
-      .replace(/<\/ja\s*>/g, "");
+    const tokens = tokenizeWaniKaniMnemonic(mnemonic);
+    if (tokens.length === 0) return null;
 
-    // Split the text by these tags to process them
-    const segments: React.ReactNode[] = [];
-
-    // Regular expression to find <em>, <radical>, <kanji>, <vocabulary>, <reading>, <ja> tags
-    const regex =
-      /<(em|radical|kanji|vocabulary|reading|ja)>(.*?)<\/\1>|([^<]+)/g;
-    let match;
-    let index = 0;
-
-    while ((match = regex.exec(processedText)) !== null) {
-      if (match[3]) {
-        // Regular text
-        segments.push(
+    const segments: React.ReactNode[] = tokens.map((token, index) => {
+      if (token.type === "em") {
+        return (
           <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[3]}
-          </Text>
-        );
-      } else if (match[1] === "em") {
-        // Emphasized text
-        segments.push(
-          <Text
-            key={index++}
+            key={index}
             style={[styles.emText, { color: theme.textColor }]}
           >
-            {match[2]}
-          </Text>
-        );
-      } else if (match[1] === "radical") {
-        // Radical text
-        segments.push(
-          <View key={index++} style={styles.inlineRadicalTag}>
-            <Text style={styles.radicalTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "kanji") {
-        // Kanji text
-        segments.push(
-          <View key={index++} style={styles.inlineKanjiTag}>
-            <Text style={styles.kanjiTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "vocabulary") {
-        // Vocabulary text
-        segments.push(
-          <View key={index++} style={styles.inlineVocabTag}>
-            <Text style={styles.vocabTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "reading") {
-        // Reading text
-        segments.push(
-          <View key={index++} style={styles.inlineReadingTag}>
-            <Text style={styles.readingTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "ja") {
-        // Japanese text (render as plain text)
-        segments.push(
-          <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[2]}
+            {token.text}
           </Text>
         );
       }
-    }
+
+      if (token.type === "radical") {
+        return (
+          <View key={index} style={styles.inlineRadicalTag}>
+            <Text style={styles.radicalTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "kanji") {
+        return (
+          <View key={index} style={styles.inlineKanjiTag}>
+            <Text style={styles.kanjiTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "vocabulary") {
+        return (
+          <View key={index} style={styles.inlineVocabTag}>
+            <Text style={styles.vocabTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "reading") {
+        return (
+          <View key={index} style={styles.inlineReadingTag}>
+            <Text style={styles.readingTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      return (
+        <Text
+          key={index}
+          style={[styles.mnemonicText, { color: theme.textColor }]}
+        >
+          {token.text}
+        </Text>
+      );
+    });
 
     return <Text style={styles.mnemonicTextContainer}>{segments}</Text>;
   };

--- a/src/components/LessonDetailScreen.tsx
+++ b/src/components/LessonDetailScreen.tsx
@@ -85,6 +85,7 @@ import {
 } from "../utils/subjectColors";
 import { useAuthStore, useSettingsStore } from "../utils/store";
 import { useTheme } from "../utils/theme";
+import { tokenizeWaniKaniMnemonic } from "../utils/wanikaniMnemonic";
 import KanjiPracticeModal from "./KanjiPracticeModal";
 import PitchAccentVisualization from "./PitchAccentVisualization";
 import StrokeOrderAnimation from "./StrokeOrderAnimation";
@@ -1350,82 +1351,64 @@ const SubjectContent = ({
   const formatMnemonic = (mnemonic: string) => {
     if (!mnemonic) return null;
 
-    // Replace HTML entities
-    let processedText = mnemonic.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
-    // Strip <ja> tags (open/self-closing and closing) entirely
-    processedText = processedText
-      .replace(/<ja\s*\/?>/g, "")
-      .replace(/<\/ja\s*>/g, "");
+    const tokens = tokenizeWaniKaniMnemonic(mnemonic);
+    if (tokens.length === 0) return null;
 
-    // Split the text by these tags to process them
-    const segments: React.ReactNode[] = [];
-
-    // Regular expression to find <em>, <radical>, <kanji>, <vocabulary>, <reading>, <ja> tags
-    const regex =
-      /<(em|radical|kanji|vocabulary|reading|ja)>(.*?)<\/\1>|([^<]+)/g;
-    let match;
-    let index = 0;
-
-    while ((match = regex.exec(processedText)) !== null) {
-      if (match[3]) {
-        // Regular text
-        segments.push(
-          <Text key={index++} style={styles.mnemonicText}>
-            {match[3]}
-          </Text>
-        );
-      } else if (match[1] === "em") {
-        // Emphasized text
-        segments.push(
-          <Text key={index++} style={styles.emText}>
-            {match[2]}
-          </Text>
-        );
-      } else if (match[1] === "radical") {
-        // Radical text
-        segments.push(
-          <Text key={index++}>
-            <View style={styles.inlineRadicalTag}>
-              <Text style={styles.radicalTagText}>{match[2]}</Text>
-            </View>
-          </Text>
-        );
-      } else if (match[1] === "kanji") {
-        // Kanji text
-        segments.push(
-          <Text key={index++}>
-            <View style={styles.inlineKanjiTag}>
-              <Text style={styles.kanjiTagText}>{match[2]}</Text>
-            </View>
-          </Text>
-        );
-      } else if (match[1] === "vocabulary") {
-        // Vocabulary text
-        segments.push(
-          <Text key={index++}>
-            <View style={styles.inlineVocabTag}>
-              <Text style={styles.vocabTagText}>{match[2]}</Text>
-            </View>
-          </Text>
-        );
-      } else if (match[1] === "reading") {
-        // Reading text
-        segments.push(
-          <Text key={index++}>
-            <View style={styles.inlineReadingTag}>
-              <Text style={styles.readingTagText}>{match[2]}</Text>
-            </View>
-          </Text>
-        );
-      } else if (match[1] === "ja") {
-        // Japanese text (render as plain text)
-        segments.push(
-          <Text key={index++} style={styles.mnemonicText}>
-            {match[2]}
+    const segments: React.ReactNode[] = tokens.map((token, index) => {
+      if (token.type === "em") {
+        return (
+          <Text key={index} style={styles.emText}>
+            {token.text}
           </Text>
         );
       }
-    }
+
+      if (token.type === "radical") {
+        return (
+          <Text key={index}>
+            <View style={styles.inlineRadicalTag}>
+              <Text style={styles.radicalTagText}>{token.text}</Text>
+            </View>
+          </Text>
+        );
+      }
+
+      if (token.type === "kanji") {
+        return (
+          <Text key={index}>
+            <View style={styles.inlineKanjiTag}>
+              <Text style={styles.kanjiTagText}>{token.text}</Text>
+            </View>
+          </Text>
+        );
+      }
+
+      if (token.type === "vocabulary") {
+        return (
+          <Text key={index}>
+            <View style={styles.inlineVocabTag}>
+              <Text style={styles.vocabTagText}>{token.text}</Text>
+            </View>
+          </Text>
+        );
+      }
+
+      if (token.type === "reading") {
+        return (
+          <Text key={index}>
+            <View style={styles.inlineReadingTag}>
+              <Text style={styles.readingTagText}>{token.text}</Text>
+            </View>
+          </Text>
+        );
+      }
+
+      return (
+        <Text key={index} style={styles.mnemonicText}>
+          {token.text}
+        </Text>
+      );
+    });
 
     return <Text style={styles.mnemonicTextContainer}>{segments}</Text>;
   };

--- a/src/components/RadicalDetails.tsx
+++ b/src/components/RadicalDetails.tsx
@@ -42,6 +42,7 @@ import {
 } from "../utils/subjectColors";
 import { useSettingsStore } from "../utils/store";
 import { useTheme } from "../utils/theme";
+import { tokenizeWaniKaniMnemonic } from "../utils/wanikaniMnemonic";
 import { CopyTooltip, useCopyTooltip } from "./CopyTooltip";
 import SrsLevelIcon from "./SrsLevelIcon";
 import { SynonymsModal } from "./SynonymsModal";
@@ -390,68 +391,46 @@ export default function RadicalDetails({
   const formatMnemonic = (mnemonic: string) => {
     if (!mnemonic) return null;
 
-    // Replace HTML entities
-    let processedText = mnemonic.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
-    // Strip <ja> tags (open/self-closing and closing) entirely
-    processedText = processedText
-      .replace(/<ja\s*\/?>/g, "")
-      .replace(/<\/ja\s*>/g, "");
+    const tokens = tokenizeWaniKaniMnemonic(mnemonic);
+    if (tokens.length === 0) return null;
 
-    // Split the text by these tags to process them
-    const segments: React.ReactNode[] = [];
-
-    // Regular expression to find <em>, <radical>, <reading>, <ja> tags
-    const regex = /<(em|radical|reading|ja)>(.*?)<\/\1>|([^<]+)/g;
-    let match;
-    let index = 0;
-
-    while ((match = regex.exec(processedText)) !== null) {
-      if (match[3]) {
-        // Regular text
-        segments.push(
+    const segments: React.ReactNode[] = tokens.map((token, index) => {
+      if (token.type === "em") {
+        return (
           <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[3]}
-          </Text>
-        );
-      } else if (match[1] === "em") {
-        // Emphasized text
-        segments.push(
-          <Text
-            key={index++}
+            key={index}
             style={[styles.emText, { color: theme.textColor }]}
           >
-            {match[2]}
-          </Text>
-        );
-      } else if (match[1] === "radical") {
-        // Radical text
-        segments.push(
-          <View key={index++} style={styles.inlineRadicalTag}>
-            <Text style={styles.radicalTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "reading") {
-        // Reading text
-        segments.push(
-          <View key={index++} style={styles.inlineReadingTag}>
-            <Text style={styles.readingTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "ja") {
-        // Japanese text (render as plain text)
-        segments.push(
-          <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[2]}
+            {token.text}
           </Text>
         );
       }
-    }
+
+      if (token.type === "radical") {
+        return (
+          <View key={index} style={styles.inlineRadicalTag}>
+            <Text style={styles.radicalTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "reading") {
+        return (
+          <View key={index} style={styles.inlineReadingTag}>
+            <Text style={styles.readingTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      return (
+        <Text
+          key={index}
+          style={[styles.mnemonicText, { color: theme.textColor }]}
+        >
+          {token.text}
+        </Text>
+      );
+    });
 
     return <Text style={styles.mnemonicTextContainer}>{segments}</Text>;
   };

--- a/src/components/ReviewQuestionScreen.tsx
+++ b/src/components/ReviewQuestionScreen.tsx
@@ -1132,6 +1132,8 @@ export default function ReviewQuestionScreen({
   const [wrongAnswerText, setWrongAnswerText] = useState<string | null>(null);
   const [closeAnswerText, setCloseAnswerText] = useState<string | null>(null);
   const [correctAnswerText, setCorrectAnswerText] = useState<string | null>(null);
+  const [reviewDetailSubject, setReviewDetailSubject] =
+    useState<WKSubject | null>(null);
   const [reviewDetailRelatedSubjects, setReviewDetailRelatedSubjects] =
     useState<ReviewDetailRelatedSubjects>(
       EMPTY_REVIEW_DETAIL_RELATED_SUBJECTS,
@@ -1226,6 +1228,7 @@ export default function ReviewQuestionScreen({
   useEffect(() => {
     let cancelled = false;
 
+    setReviewDetailSubject(null);
     setReviewDetailRelatedSubjects(EMPTY_REVIEW_DETAIL_RELATED_SUBJECTS);
 
     if (!effectiveShowAnswerStopSubjectDetails) {
@@ -1235,7 +1238,16 @@ export default function ReviewQuestionScreen({
     }
 
     const loadReviewDetailRelatedSubjects = async () => {
-      const subjectData = getSubjectDataRecord(item.subject);
+      const cachedSubject = normalizeCachedSubject(
+        await getSubjectById(item.subject.id),
+      );
+      const detailSubject = cachedSubject ?? item.subject;
+
+      if (!cancelled && cachedSubject) {
+        setReviewDetailSubject(cachedSubject);
+      }
+
+      const subjectData = getSubjectDataRecord(detailSubject);
       const componentIds = getSubjectIdList(subjectData.component_subject_ids);
       const amalgamationIds = getSubjectIdList(
         subjectData.amalgamation_subject_ids,
@@ -1250,7 +1262,7 @@ export default function ReviewQuestionScreen({
       ]);
 
       let visuallySimilarSubjects: WKSubject[] = [];
-      if (item.subject.object === "kanji") {
+      if (detailSubject.object === "kanji") {
         if (visuallySimilarKanjiSource === "niai") {
           const kanjiCharacter = subjectData.characters;
           if (typeof kanjiCharacter === "string" && kanjiCharacter.length > 0) {
@@ -3263,7 +3275,10 @@ export default function ReviewQuestionScreen({
   ]);
 
   const renderPausedSubjectDetails = () => {
-    const subject = item.subject;
+    const subject =
+      reviewDetailSubject?.id === item.subject.id
+        ? reviewDetailSubject
+        : item.subject;
     const data = getSubjectDataRecord(subject);
     const meanings = getSubjectMeanings(subject);
     const readings = getSubjectReadings(subject);

--- a/src/components/SubjectTabs.tsx
+++ b/src/components/SubjectTabs.tsx
@@ -19,6 +19,7 @@ import { hiraganaToKata } from "../utils/katakanaMadness";
 import { pickBestImage, useRemoteSvg } from "../utils/radicalSvg";
 import { type SubjectColors, useSubjectColors } from "../utils/subjectColors";
 import { useSettingsStore } from "../utils/store";
+import { stripWaniKaniMnemonicMarkup } from "../utils/wanikaniMnemonic";
 
 const { width } = Dimensions.get("window");
 
@@ -184,14 +185,7 @@ export default function SubjectTabs({
   const cleanMnemonicText = (text: string) => {
     if (!text) return "";
 
-    // Replace HTML tags with plain text
-    return text
-      .replace(/<[^>]*>/g, "") // Remove HTML tags
-      .replace(/&lt;/g, "<") // Replace HTML entities
-      .replace(/&gt;/g, ">")
-      .replace(/&amp;/g, "&")
-      .replace(/&quot;/g, '"')
-      .replace(/&apos;/g, "'");
+    return stripWaniKaniMnemonicMarkup(text);
   };
 
   // Play audio for vocabulary items

--- a/src/components/VocabularyDetails.tsx
+++ b/src/components/VocabularyDetails.tsx
@@ -48,6 +48,7 @@ import { useAuthStore, useSettingsStore } from "../utils/store";
 import { useTheme } from "../utils/theme";
 import { getAllSubjects } from "../utils/cache";
 import type { Subject } from "../utils/api";
+import { tokenizeWaniKaniMnemonic } from "../utils/wanikaniMnemonic";
 import { CopyTooltip, useCopyTooltip } from "./CopyTooltip";
 import PitchAccentVisualization from "./PitchAccentVisualization";
 import SrsLevelIcon from "./SrsLevelIcon";
@@ -1129,83 +1130,62 @@ export default function VocabularyDetails({
   const formatMnemonic = (mnemonic: string) => {
     if (!mnemonic) return null;
 
-    // Replace HTML entities
-    let processedText = mnemonic.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
-    // Strip <ja> tags (open/self-closing and closing) entirely
-    processedText = processedText
-      .replace(/<ja\s*\/?>/g, "")
-      .replace(/<\/ja\s*>/g, "");
+    const tokens = tokenizeWaniKaniMnemonic(mnemonic);
+    if (tokens.length === 0) return null;
 
-    // Split the text by these tags to process them
-    const segments: React.ReactNode[] = [];
-
-    // Regular expression to find <em>, <radical>, <kanji>, <vocabulary>, <reading>, <ja> tags
-    const regex =
-      /<(em|radical|kanji|vocabulary|reading|ja)>(.*?)<\/\1>|([^<]+)/g;
-    let match;
-    let index = 0;
-
-    while ((match = regex.exec(processedText)) !== null) {
-      if (match[3]) {
-        // Regular text
-        segments.push(
+    const segments: React.ReactNode[] = tokens.map((token, index) => {
+      if (token.type === "em") {
+        return (
           <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[3]}
-          </Text>
-        );
-      } else if (match[1] === "em") {
-        // Emphasized text
-        segments.push(
-          <Text
-            key={index++}
+            key={index}
             style={[styles.emText, { color: theme.textColor }]}
           >
-            {match[2]}
-          </Text>
-        );
-      } else if (match[1] === "radical") {
-        // Radical text
-        segments.push(
-          <View key={index++} style={styles.inlineRadicalTag}>
-            <Text style={styles.radicalTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "kanji") {
-        // Kanji text
-        segments.push(
-          <View key={index++} style={styles.inlineKanjiTag}>
-            <Text style={styles.kanjiTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "vocabulary") {
-        // Vocabulary text
-        segments.push(
-          <View key={index++} style={styles.inlineVocabTag}>
-            <Text style={styles.vocabTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "reading") {
-        // Reading text
-        segments.push(
-          <View key={index++} style={styles.inlineReadingTag}>
-            <Text style={styles.readingTagText}>{match[2]}</Text>
-          </View>
-        );
-      } else if (match[1] === "ja") {
-        // Japanese text (render as plain text)
-        segments.push(
-          <Text
-            key={index++}
-            style={[styles.mnemonicText, { color: theme.textColor }]}
-          >
-            {match[2]}
+            {token.text}
           </Text>
         );
       }
-    }
+
+      if (token.type === "radical") {
+        return (
+          <View key={index} style={styles.inlineRadicalTag}>
+            <Text style={styles.radicalTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "kanji") {
+        return (
+          <View key={index} style={styles.inlineKanjiTag}>
+            <Text style={styles.kanjiTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "vocabulary") {
+        return (
+          <View key={index} style={styles.inlineVocabTag}>
+            <Text style={styles.vocabTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      if (token.type === "reading") {
+        return (
+          <View key={index} style={styles.inlineReadingTag}>
+            <Text style={styles.readingTagText}>{token.text}</Text>
+          </View>
+        );
+      }
+
+      return (
+        <Text
+          key={index}
+          style={[styles.mnemonicText, { color: theme.textColor }]}
+        >
+          {token.text}
+        </Text>
+      );
+    });
 
     return <Text style={styles.mnemonicTextContainer}>{segments}</Text>;
   };

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.82",
+    date: "2026-06-18",
+    changes: [
+      {
+        type: "fix",
+        title: "WaniKani Mnemonic Tags",
+        description:
+          "Fixed WaniKani mnemonic rendering so malformed reading tags no longer show tag fragments in review and subject details.",
+      },
+    ],
+  },
+  {
     version: "1.2.81",
     date: "2026-06-17",
     changes: [

--- a/src/utils/__tests__/wanikaniMnemonic.test.ts
+++ b/src/utils/__tests__/wanikaniMnemonic.test.ts
@@ -1,0 +1,62 @@
+import {
+  normalizeWaniKaniMnemonicMarkup,
+  stripWaniKaniMnemonicMarkup,
+  tokenizeWaniKaniMnemonic,
+} from "../wanikaniMnemonic";
+
+describe("wanikaniMnemonic", () => {
+  it("tokenizes standard WaniKani mnemonic tags", () => {
+    expect(
+      tokenizeWaniKaniMnemonic(
+        "Remember the <kanji>car</kanji> reading <reading>しゃ</reading>.",
+      ),
+    ).toEqual([
+      { type: "text", text: "Remember the " },
+      { type: "kanji", text: "car" },
+      { type: "text", text: " reading " },
+      { type: "reading", text: "しゃ" },
+      { type: "text", text: "." },
+    ]);
+  });
+
+  it("normalizes the malformed reading closing tag seen in mnemonic data", () => {
+    expect(
+      stripWaniKaniMnemonicMarkup("The reading is <reading>hah</erading> (は)."),
+    ).toBe("The reading is hah (は).");
+
+    expect(
+      tokenizeWaniKaniMnemonic("The reading is <reading>hah</erading> (は)."),
+    ).toEqual([
+      { type: "text", text: "The reading is " },
+      { type: "reading", text: "hah" },
+      { type: "text", text: " (は)." },
+    ]);
+  });
+
+  it("normalizes tag fragments that already lost their opening angle brackets", () => {
+    expect(normalizeWaniKaniMnemonicMarkup("reading>hah/erading> (は)")).toBe(
+      "<reading>hah</reading> (は)",
+    );
+    expect(stripWaniKaniMnemonicMarkup("reading>hah/erading> (は)")).toBe(
+      "hah (は)",
+    );
+  });
+
+  it("decodes escaped tags before stripping markup", () => {
+    expect(
+      tokenizeWaniKaniMnemonic(
+        "Say &lt;reading&gt;は&lt;/reading&gt; &amp; continue.",
+      ),
+    ).toEqual([
+      { type: "text", text: "Say " },
+      { type: "reading", text: "は" },
+      { type: "text", text: " & continue." },
+    ]);
+  });
+
+  it("keeps Japanese tag contents as plain text", () => {
+    expect(stripWaniKaniMnemonicMarkup("Read <ja>日本語</ja> aloud.")).toBe(
+      "Read 日本語 aloud.",
+    );
+  });
+});

--- a/src/utils/wanikaniMnemonic.ts
+++ b/src/utils/wanikaniMnemonic.ts
@@ -1,0 +1,152 @@
+const WANI_KANI_MNEMONIC_TAGS = [
+  "em",
+  "radical",
+  "kanji",
+  "vocabulary",
+  "reading",
+  "ja",
+] as const;
+
+type WaniKaniMnemonicTag = (typeof WANI_KANI_MNEMONIC_TAGS)[number];
+
+export type WaniKaniMnemonicTokenType =
+  | "text"
+  | "em"
+  | "radical"
+  | "kanji"
+  | "vocabulary"
+  | "reading";
+
+export interface WaniKaniMnemonicToken {
+  type: WaniKaniMnemonicTokenType;
+  text: string;
+}
+
+const KNOWN_TAGS = new Set<string>(WANI_KANI_MNEMONIC_TAGS);
+
+const TAG_ALIASES: Record<string, WaniKaniMnemonicTag> = {
+  erading: "reading",
+};
+
+function decodeNumericEntity(
+  rawValue: string,
+  radix: 10 | 16,
+  fallback: string,
+): string {
+  const codePoint = Number.parseInt(rawValue, radix);
+  if (!Number.isFinite(codePoint)) {
+    return fallback;
+  }
+
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return fallback;
+  }
+}
+
+export function decodeWaniKaniMnemonicEntities(value: string): string {
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&nbsp;|&#160;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (match, hexValue: string) =>
+      decodeNumericEntity(hexValue, 16, match),
+    )
+    .replace(/&#(\d+);/g, (match, decimalValue: string) =>
+      decodeNumericEntity(decimalValue, 10, match),
+    );
+}
+
+function resolveMnemonicTagName(rawName: string): WaniKaniMnemonicTag | null {
+  const normalizedName = rawName.trim().toLowerCase();
+  const aliasedName = TAG_ALIASES[normalizedName];
+  if (aliasedName) {
+    return aliasedName;
+  }
+
+  return KNOWN_TAGS.has(normalizedName)
+    ? (normalizedName as WaniKaniMnemonicTag)
+    : null;
+}
+
+export function normalizeWaniKaniMnemonicMarkup(value: string): string {
+  return decodeWaniKaniMnemonicEntities(value)
+    .replace(/\breading>([^<>]*?)\/erading>/gi, "<reading>$1</reading>")
+    .replace(/\breading>([^<>]*?)\/reading>/gi, "<reading>$1</reading>")
+    .replace(/<\s*\/\s*erading\s*>/gi, "</reading>")
+    .replace(/<\s*erading(\s[^>]*)?>/gi, "<reading$1>");
+}
+
+function tokenTypeForTag(
+  tag: WaniKaniMnemonicTag | undefined,
+): WaniKaniMnemonicTokenType {
+  return tag && tag !== "ja" ? tag : "text";
+}
+
+export function tokenizeWaniKaniMnemonic(
+  mnemonic: string,
+): WaniKaniMnemonicToken[] {
+  if (!mnemonic) {
+    return [];
+  }
+
+  const source = normalizeWaniKaniMnemonicMarkup(mnemonic);
+  const tokens: WaniKaniMnemonicToken[] = [];
+  const openTagStack: WaniKaniMnemonicTag[] = [];
+  const tagRegex = /<\s*(\/?)\s*([a-z][\w-]*)\b([^>]*)>/gi;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  const appendText = (text: string) => {
+    if (!text) {
+      return;
+    }
+
+    const type = tokenTypeForTag(openTagStack[openTagStack.length - 1]);
+    const previousToken = tokens[tokens.length - 1];
+    if (previousToken?.type === type) {
+      previousToken.text += text;
+      return;
+    }
+
+    tokens.push({ type, text });
+  };
+
+  while ((match = tagRegex.exec(source)) !== null) {
+    appendText(source.slice(cursor, match.index));
+    cursor = tagRegex.lastIndex;
+
+    const isClosingTag = match[1] === "/";
+    const tagName = resolveMnemonicTagName(match[2]);
+    if (!tagName) {
+      continue;
+    }
+
+    if (isClosingTag) {
+      const matchingIndex = openTagStack.lastIndexOf(tagName);
+      if (matchingIndex >= 0) {
+        openTagStack.splice(matchingIndex);
+      }
+      continue;
+    }
+
+    const attributes = match[3] ?? "";
+    const isSelfClosing = /\/\s*$/.test(attributes);
+    if (!isSelfClosing) {
+      openTagStack.push(tagName);
+    }
+  }
+
+  appendText(source.slice(cursor));
+  return tokens;
+}
+
+export function stripWaniKaniMnemonicMarkup(mnemonic: string): string {
+  return tokenizeWaniKaniMnemonic(mnemonic)
+    .map((token) => token.text)
+    .join("");
+}


### PR DESCRIPTION
## Summary
- Normalize WaniKani mnemonic markup through a shared renderer used by review, subject, and lesson details.
- Handle malformed reading tags like `</erading>` and `reading>.../erading>` without showing tag fragments in the UI.
