### PR TITLE
[Fix] Lesson order level priority

### DIFF
--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -65,6 +65,12 @@ export const PATCH_NOTES: PatchNote[] = [
         description:
           "Added an Add to Subject List action to Recent Mistakes so the current mistake batch can be saved into custom subject lists for mixed review sessions.",
       },
+      {
+        type: "fix",
+        title: "Lesson Order Level Priority",
+        description:
+          "Fixed interleaved lessons so lowest-level-first ordering finishes older-level items before newly unlocked level items.",
+      },
     ],
   },
   {

--- a/src/utils/__tests__/lessonOrdering.test.ts
+++ b/src/utils/__tests__/lessonOrdering.test.ts
@@ -99,6 +99,22 @@ describe("lessonOrdering", () => {
     expect(sorted.map((item) => item.id)).toEqual([1, 3, 2]);
   });
 
+  it("uses WaniKani subject order as the tie-breaker for lowest level first", () => {
+    const items = [
+      createTestItem({ id: 1, level: 5, subjectId: 30 }),
+      createTestItem({ id: 2, level: 5, subjectId: 10 }),
+      createTestItem({ id: 3, level: 5, subjectId: 20 }),
+      createTestItem({ id: 4, level: 6, subjectId: 1 }),
+    ];
+
+    const sorted = sortLessonItemsForQueue(items, {
+      lessonOrder: "lowestLevelFirst",
+      randomFn: constantRandom(0),
+    });
+
+    expect(sorted.map((item) => item.id)).toEqual([2, 3, 1, 4]);
+  });
+
   it("prioritizes critical (current level radical/kanji) items", () => {
     const items = [
       createTestItem({ id: 1, subjectType: "vocabulary", level: 10 }),
@@ -216,6 +232,52 @@ describe("lessonOrdering", () => {
 
     const topTwoIds = sorted.slice(0, 2).map((item) => item.id).sort();
     expect(topTwoIds).toEqual([2, 3]);
+  });
+
+  it("keeps lower-level lessons ahead of new-level items when interleaving", () => {
+    const items = [
+      createTestItem({
+        id: 1,
+        subjectType: "radical",
+        level: 11,
+        subjectId: 100,
+      }),
+      createTestItem({
+        id: 2,
+        subjectType: "kanji",
+        level: 11,
+        subjectId: 200,
+      }),
+      createTestItem({
+        id: 3,
+        subjectType: "vocabulary",
+        level: 10,
+        subjectId: 3000,
+      }),
+      createTestItem({
+        id: 4,
+        subjectType: "vocabulary",
+        level: 10,
+        subjectId: 3001,
+      }),
+      createTestItem({
+        id: 5,
+        subjectType: "vocabulary",
+        level: 10,
+        subjectId: 3002,
+      }),
+    ];
+
+    const sorted = sortLessonItemsForQueue(items, {
+      lessonOrder: "lowestLevelFirst",
+      interleaveLessonTypesEnabled: true,
+      randomFn: constantRandom(0),
+    });
+
+    expect(sorted.map((item) => item.subject.data.level)).toEqual([
+      10, 10, 10, 11, 11,
+    ]);
+    expect(sorted.map((item) => item.id)).toEqual([3, 4, 5, 1, 2]);
   });
 
   it("pulls radicals and kanji into each batch when minimum type coverage is enabled", () => {

--- a/src/utils/lessonOrdering.ts
+++ b/src/utils/lessonOrdering.ts
@@ -39,7 +39,8 @@ export const LESSON_ORDER_OPTIONS: readonly LessonOrderOption[] = [
   {
     value: "lowestLevelFirst",
     label: "Lowest level first",
-    description: "Prioritize lower-level (older) lessons first.",
+    description:
+      "Prioritize lower-level (older) lessons first, then WaniKani order.",
   },
   {
     value: "newestUnlockedFirst",
@@ -197,10 +198,18 @@ function compareByLessonOrder(
   switch (lessonOrder) {
     case "random":
       return 0;
-    case "currentLevelFirst":
-      return (right.subject.data.level ?? 0) - (left.subject.data.level ?? 0);
-    case "lowestLevelFirst":
-      return (left.subject.data.level ?? 0) - (right.subject.data.level ?? 0);
+    case "currentLevelFirst": {
+      const levelComparison =
+        (right.subject.data.level ?? 0) - (left.subject.data.level ?? 0);
+      if (levelComparison !== 0) return levelComparison;
+      return (left.subjectId ?? 0) - (right.subjectId ?? 0);
+    }
+    case "lowestLevelFirst": {
+      const levelComparison =
+        (left.subject.data.level ?? 0) - (right.subject.data.level ?? 0);
+      if (levelComparison !== 0) return levelComparison;
+      return (left.subjectId ?? 0) - (right.subjectId ?? 0);
+    }
     case "newestUnlockedFirst":
       return compareDateDescending(left.availableAt, right.availableAt);
     case "oldestUnlockedFirst":
@@ -364,6 +373,56 @@ function interleaveItemsBySubjectType<T extends OrderableLessonItem>(
   return interleaved;
 }
 
+function shouldInterleaveWithinLessonOrderGroups(
+  lessonOrder: LessonOrderSetting
+): boolean {
+  return (
+    lessonOrder === "currentLevelFirst" || lessonOrder === "lowestLevelFirst"
+  );
+}
+
+function getLessonOrderGroupKey(item: OrderableLessonItem): number {
+  return item.subject.data.level ?? 0;
+}
+
+function interleaveLessonOrderGroupsBySubjectType<T extends OrderableLessonItem>(
+  sortedItems: T[],
+  lessonOrder: LessonOrderSetting,
+  lessonTypeOrder: LessonTypeOrderSetting[]
+): T[] {
+  if (
+    sortedItems.length <= 1 ||
+    !shouldInterleaveWithinLessonOrderGroups(lessonOrder)
+  ) {
+    return interleaveItemsBySubjectType(sortedItems, lessonTypeOrder);
+  }
+
+  const interleaved: T[] = [];
+  let currentGroup: T[] = [];
+  let currentGroupKey: number | null = null;
+
+  sortedItems.forEach((item) => {
+    const groupKey = getLessonOrderGroupKey(item);
+    if (currentGroupKey !== null && groupKey !== currentGroupKey) {
+      interleaved.push(
+        ...interleaveItemsBySubjectType(currentGroup, lessonTypeOrder)
+      );
+      currentGroup = [];
+    }
+
+    currentGroupKey = groupKey;
+    currentGroup.push(item);
+  });
+
+  if (currentGroup.length > 0) {
+    interleaved.push(
+      ...interleaveItemsBySubjectType(currentGroup, lessonTypeOrder)
+    );
+  }
+
+  return interleaved;
+}
+
 function countBatchMinimumTypes<T extends OrderableLessonItem>(
   batch: T[],
   minimumTypes: LessonTypeOrderSetting[]
@@ -507,8 +566,9 @@ export function sortLessonItemsForQueue<T extends OrderableLessonItem>(
     );
 
     if (!prioritizeCriticalItems) {
-      sortedItems = interleaveItemsBySubjectType(
+      sortedItems = interleaveLessonOrderGroupsBySubjectType(
         baseSorted,
+        lessonOrder,
         normalizedTypeOrder
       );
     } else {
@@ -524,8 +584,16 @@ export function sortLessonItemsForQueue<T extends OrderableLessonItem>(
       });
 
       sortedItems = [
-        ...interleaveItemsBySubjectType(criticalItems, normalizedTypeOrder),
-        ...interleaveItemsBySubjectType(nonCriticalItems, normalizedTypeOrder),
+        ...interleaveLessonOrderGroupsBySubjectType(
+          criticalItems,
+          lessonOrder,
+          normalizedTypeOrder
+        ),
+        ...interleaveLessonOrderGroupsBySubjectType(
+          nonCriticalItems,
+          lessonOrder,
+          normalizedTypeOrder
+        ),
       ];
     }
   } else {


### PR DESCRIPTION
## Summary
- Keep lowest-level lessons ahead of newly unlocked level items when interleaving lesson types.
- Use WaniKani subject order as the tie-breaker for level-first lesson ordering.
