### PR TITLE
fix: improve context sentence distractors

### DIFF
--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -69,6 +69,12 @@ export const PATCH_NOTES: PatchNote[] = [
           label: "Open Subject Lists",
         },
       },
+      {
+        type: "fix",
+        title: "Context Sentence Choices",
+        description:
+          "Multiple-choice context sentence practice now prefers answer choices with matching parts of speech, making distractors less obvious from grammar alone.",
+      },
     ],
   },
   {

--- a/src/services/__tests__/contextSentencePracticeService.test.ts
+++ b/src/services/__tests__/contextSentencePracticeService.test.ts
@@ -1,0 +1,212 @@
+import { generateContextSentenceQuestions } from "../contextSentencePracticeService";
+import { getAllAssignmentsCached } from "../../utils/api";
+import { getSubjectById } from "../../utils/cache";
+
+jest.mock("../../utils/api", () => ({
+  getAllAssignmentsCached: jest.fn(),
+}));
+
+jest.mock("../../utils/cache", () => ({
+  getSubjectById: jest.fn(),
+}));
+
+jest.mock("../../utils/extraStudySubjectLists", () => ({
+  getSelectedListSubjectIdSet: jest.fn(async () => new Set()),
+  subjectMatchesSelectedLists: jest.fn(() => true),
+}));
+
+const makeSubject = ({
+  id,
+  characters,
+  reading,
+  partsOfSpeech,
+  level = 1,
+}: {
+  id: number;
+  characters: string;
+  reading: string;
+  partsOfSpeech: string[];
+  level?: number;
+}) => ({
+  id,
+  object: "vocabulary",
+  url: `https://api.wanikani.com/v2/subjects/${id}`,
+  data_updated_at: "2026-06-20T00:00:00.000Z",
+  data: {
+    created_at: "2026-06-20T00:00:00.000Z",
+    level,
+    slug: characters,
+    hidden_at: null,
+    document_url: `https://www.wanikani.com/vocabulary/${characters}`,
+    characters,
+    character_images: null,
+    meanings: [{ meaning: characters, primary: true, accepted_answer: true }],
+    auxiliary_meanings: [],
+    readings: [{ reading, primary: true, accepted_answer: true, type: "onyomi" }],
+    parts_of_speech: partsOfSpeech,
+    component_subject_ids: null,
+    amalgamation_subject_ids: null,
+    visually_similar_subject_ids: null,
+    meaning_mnemonic: "",
+    meaning_hint: null,
+    reading_mnemonic: null,
+    reading_hint: null,
+    context_sentences: [
+      {
+        ja: `${characters}です。`,
+        en: `It is ${characters}.`,
+      },
+    ],
+  },
+});
+
+const makeConfig = () => ({
+  includeVocabulary: true,
+  includeKanaVocabulary: false,
+  solutionMode: "multiple_choice" as const,
+  numberOfQuestions: 1,
+  enableSentenceAudio: false,
+  autoPlaySentenceAudio: false,
+  hideTranslationUntilTap: false,
+  enableJpdbSentenceBreakdown: false,
+  stopAfterAnswer: false,
+  srsGroups: {
+    apprentice: true,
+    guru: false,
+    master: false,
+    enlightened: false,
+    burned: false,
+  },
+  useCustomLevelRange: false,
+  minLevel: 1,
+  maxLevel: 60,
+  devSelectedSubjectIds: [1],
+});
+
+const mockEligibleSubjects = (subjects: ReturnType<typeof makeSubject>[]) => {
+  const subjectById = new Map(subjects.map((subject) => [subject.id, subject]));
+
+  (getAllAssignmentsCached as jest.Mock).mockResolvedValue({
+    data: subjects.map((subject) => ({
+      data: {
+        subject_id: subject.id,
+        srs_stage: 1,
+      },
+    })),
+  });
+  (getSubjectById as jest.Mock).mockImplementation((subjectId: number) =>
+    Promise.resolve(subjectById.get(subjectId))
+  );
+};
+
+describe("generateContextSentenceQuestions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("prefers distractors with the same part of speech as the correct answer", async () => {
+    const subjects = [
+      makeSubject({
+        id: 1,
+        characters: "世界",
+        reading: "せかい",
+        partsOfSpeech: ["noun"],
+      }),
+      makeSubject({
+        id: 2,
+        characters: "学生",
+        reading: "がくせい",
+        partsOfSpeech: ["noun"],
+      }),
+      makeSubject({
+        id: 3,
+        characters: "道",
+        reading: "みち",
+        partsOfSpeech: ["noun"],
+      }),
+      makeSubject({
+        id: 4,
+        characters: "本",
+        reading: "ほん",
+        partsOfSpeech: ["noun"],
+      }),
+      makeSubject({
+        id: 5,
+        characters: "果てる",
+        reading: "はてる",
+        partsOfSpeech: ["ichidan verb"],
+      }),
+      makeSubject({
+        id: 6,
+        characters: "歩く",
+        reading: "あるく",
+        partsOfSpeech: ["godan verb"],
+      }),
+    ];
+    mockEligibleSubjects(subjects);
+
+    const questions = await generateContextSentenceQuestions(makeConfig(), "token");
+    const question = questions[0];
+    const wrongChoiceIds = question.kanjiChoices
+      .filter((choice) => !choice.isCorrect)
+      .map((choice) => choice.vocabId);
+
+    expect(question.vocab.id).toBe(1);
+    expect(wrongChoiceIds).toHaveLength(3);
+    expect(wrongChoiceIds).toEqual(expect.arrayContaining([2, 3, 4]));
+    expect(wrongChoiceIds).not.toEqual(expect.arrayContaining([5, 6]));
+  });
+
+  it("keeps i-adjective distractors separate from other adjective types when available", async () => {
+    const subjects = [
+      makeSubject({
+        id: 1,
+        characters: "楽しい",
+        reading: "たのしい",
+        partsOfSpeech: ["い adjective"],
+      }),
+      makeSubject({
+        id: 2,
+        characters: "嬉しい",
+        reading: "うれしい",
+        partsOfSpeech: ["い adjective"],
+      }),
+      makeSubject({
+        id: 3,
+        characters: "新しい",
+        reading: "あたらしい",
+        partsOfSpeech: ["い adjective"],
+      }),
+      makeSubject({
+        id: 4,
+        characters: "大きい",
+        reading: "おおきい",
+        partsOfSpeech: ["い adjective"],
+      }),
+      makeSubject({
+        id: 5,
+        characters: "静か",
+        reading: "しずか",
+        partsOfSpeech: ["な adjective"],
+      }),
+      makeSubject({
+        id: 6,
+        characters: "歩く",
+        reading: "あるく",
+        partsOfSpeech: ["godan verb"],
+      }),
+    ];
+    mockEligibleSubjects(subjects);
+
+    const questions = await generateContextSentenceQuestions(makeConfig(), "token");
+    const question = questions[0];
+    const wrongChoiceIds = question.kanjiChoices
+      .filter((choice) => !choice.isCorrect)
+      .map((choice) => choice.vocabId);
+
+    expect(question.vocab.id).toBe(1);
+    expect(wrongChoiceIds).toHaveLength(3);
+    expect(wrongChoiceIds).toEqual(expect.arrayContaining([2, 3, 4]));
+    expect(wrongChoiceIds).not.toEqual(expect.arrayContaining([5, 6]));
+  });
+});

--- a/src/services/contextSentencePracticeService.ts
+++ b/src/services/contextSentencePracticeService.ts
@@ -27,6 +27,14 @@ const VERB_CONJUGATION_SUFFIX_PATTERN =
 const I_ADJECTIVE_SUFFIX_PATTERN =
   "(?:くなかった|くない|かった|くて|ければ|い)";
 
+function uniqueById(subjects: Subject[]): Subject[] {
+  return Array.from(new Map(subjects.map((subject) => [subject.id, subject])).values());
+}
+
+function shuffle<T>(items: T[]): T[] {
+  return [...items].sort(() => Math.random() - 0.5);
+}
+
 function getStageIds(config: ContextSentencePracticeConfig): number[] {
   const stageMap = {
     apprentice: [1, 2, 3, 4],
@@ -185,41 +193,159 @@ function createKanjiChoices(correct: Subject, distractors: Subject[]): KanjiChoi
   return choices.sort(() => Math.random() - 0.5);
 }
 
-function generateDistractors(correct: Subject, allVocabs: Subject[], count: number): Subject[] {
+function normalizePartOfSpeech(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+function getNormalizedPartsOfSpeech(subject: Subject): string[] {
+  const partsOfSpeech = subject.data.parts_of_speech ?? [];
+  return Array.from(
+    new Set(
+      partsOfSpeech
+        .map(normalizePartOfSpeech)
+        .filter((partOfSpeech) => partOfSpeech.length > 0)
+    )
+  ).sort();
+}
+
+function getPartOfSpeechSignature(subject: Subject): string | null {
+  const normalizedParts = getNormalizedPartsOfSpeech(subject);
+  if (normalizedParts.length === 0) {
+    return null;
+  }
+
+  return normalizedParts.join("|");
+}
+
+function getGrammarPartOfSpeechTags(partOfSpeech: string): string[] {
+  const tags: string[] = [];
+
+  if (
+    partOfSpeech.includes("い adjective") ||
+    partOfSpeech.includes("i adjective") ||
+    partOfSpeech.includes("adj i")
+  ) {
+    tags.push("i-adjective");
+  } else if (
+    partOfSpeech.includes("な adjective") ||
+    partOfSpeech.includes("na adjective") ||
+    partOfSpeech.includes("adj na")
+  ) {
+    tags.push("na-adjective");
+  } else if (
+    partOfSpeech.includes("の adjective") ||
+    partOfSpeech.includes("no adjective") ||
+    partOfSpeech.includes("adj no")
+  ) {
+    tags.push("no-adjective");
+  } else if (partOfSpeech.includes("adjective")) {
+    tags.push("adjective");
+  }
+
+  if (partOfSpeech.includes("adverb")) {
+    tags.push("adverb");
+  }
+
+  if (/(^|\s)verb(\s|$)/.test(partOfSpeech)) {
+    tags.push("verb");
+  }
+
+  if (partOfSpeech.includes("noun")) {
+    tags.push("noun");
+  }
+
+  for (const tag of [
+    "counter",
+    "expression",
+    "interjection",
+    "conjunction",
+    "prefix",
+    "suffix",
+    "numeral",
+  ]) {
+    if (partOfSpeech.includes(tag)) {
+      tags.push(tag);
+    }
+  }
+
+  return tags.length > 0 ? tags : [partOfSpeech];
+}
+
+function getSubjectGrammarTags(subject: Subject): string[] {
+  return Array.from(
+    new Set(getNormalizedPartsOfSpeech(subject).flatMap(getGrammarPartOfSpeechTags))
+  ).sort();
+}
+
+function hasCompatiblePartOfSpeech(correct: Subject, candidate: Subject): boolean {
+  const correctTags = getSubjectGrammarTags(correct);
+  if (correctTags.length === 0) {
+    return false;
+  }
+
+  const candidateTags = new Set(getSubjectGrammarTags(candidate));
+  return correctTags.some((tag) => candidateTags.has(tag));
+}
+
+function rankDistractorCandidates(correct: Subject, candidates: Subject[]): Subject[] {
   const getReading = (subject: Subject) =>
     subject.data.readings?.[0]?.reading || subject.data.characters || "";
 
   const correctReading = getReading(correct);
   const correctLevel = correct.data.level;
 
-  const similarReading = allVocabs.filter((subject) => {
-    if (subject.id === correct.id) return false;
+  const similarReading = candidates.filter((subject) => {
     const reading = getReading(subject);
     const lengthDiff = Math.abs(correctReading.length - reading.length);
     return lengthDiff <= 1;
   });
 
-  const sameLevel = allVocabs.filter(
-    (subject) => subject.id !== correct.id && subject.data.level === correctLevel
+  const sameLevel = candidates.filter(
+    (subject) => subject.data.level === correctLevel
   );
 
-  const sameFirstChar = allVocabs.filter((subject) => {
-    if (subject.id === correct.id) return false;
+  const sameFirstChar = candidates.filter((subject) => {
     const correctFirst = correct.data.characters?.[0];
     const subjectFirst = subject.data.characters?.[0];
     return Boolean(correctFirst && subjectFirst && correctFirst === subjectFirst);
   });
 
-  const randomPool = allVocabs.filter((subject) => subject.id !== correct.id);
-  const pool = [
-    ...similarReading.slice(0, 2),
-    ...sameFirstChar.slice(0, 1),
-    ...sameLevel.slice(0, 2),
-    ...randomPool,
-  ];
+  return uniqueById([
+    ...shuffle(similarReading).slice(0, 2),
+    ...shuffle(sameFirstChar).slice(0, 1),
+    ...shuffle(sameLevel).slice(0, 2),
+    ...shuffle(candidates),
+  ]);
+}
 
-  const uniquePool = Array.from(new Map(pool.map((subject) => [subject.id, subject])).values());
-  return uniquePool.sort(() => Math.random() - 0.5).slice(0, count);
+function generateDistractors(correct: Subject, allVocabs: Subject[], count: number): Subject[] {
+  const candidates = allVocabs.filter((subject) => subject.id !== correct.id);
+  const correctPartOfSpeechSignature = getPartOfSpeechSignature(correct);
+
+  const exactPartOfSpeechCandidates = correctPartOfSpeechSignature
+    ? candidates.filter(
+        (subject) => getPartOfSpeechSignature(subject) === correctPartOfSpeechSignature
+      )
+    : [];
+  const compatiblePartOfSpeechCandidates = correctPartOfSpeechSignature
+    ? candidates.filter(
+        (subject) =>
+          getPartOfSpeechSignature(subject) !== correctPartOfSpeechSignature &&
+          hasCompatiblePartOfSpeech(correct, subject)
+      )
+    : [];
+
+  const rankedPool = uniqueById([
+    ...rankDistractorCandidates(correct, exactPartOfSpeechCandidates),
+    ...rankDistractorCandidates(correct, compatiblePartOfSpeechCandidates),
+    ...rankDistractorCandidates(correct, candidates),
+  ]);
+
+  return rankedPool.slice(0, count);
 }
 
 function passesLevelRange(subject: Subject, config: ContextSentencePracticeConfig): boolean {


### PR DESCRIPTION
## Summary
- Make Context Sentence Practice multiple-choice distractors prefer matching parts of speech.
- Keep i-adjective distractors separate from other adjective types when matching options are available.
- Add regression coverage for noun and i-adjective distractor selection.
