### PR TITLE
[Fix] Radical name questions

### DIFF
--- a/src/components/ReviewQuestionScreen.tsx
+++ b/src/components/ReviewQuestionScreen.tsx
@@ -125,6 +125,17 @@ type QuestionType = "meaning" | "reading";
 
 type StudyMaterialNoteType = "meaning" | "reading";
 
+function getQuestionTypeDisplayLabel(
+  subject: WKSubject,
+  questionType: QuestionType,
+): "Name" | "Meaning" | "Reading" {
+  if (subject.object === "radical" && questionType === "meaning") {
+    return "Name";
+  }
+
+  return questionType === "meaning" ? "Meaning" : "Reading";
+}
+
 interface ReviewStudyMaterials {
   meaning_synonyms?: string[];
   meaning_note?: string;
@@ -1473,6 +1484,16 @@ export default function ReviewQuestionScreen({
     completedCount,
   );
   const subject = item.subject;
+  const questionTypeDisplayLabel = getQuestionTypeDisplayLabel(
+    subject,
+    questionType,
+  );
+  const meaningAnswerDisplayLabel =
+    subject.object === "radical" ? "name" : "meaning";
+  const groupedQuestionDisplayLabel =
+    effectiveAnkiGroupQuestions && subject.object !== "radical"
+      ? "Meaning & Reading"
+      : questionTypeDisplayLabel;
   const currentQuestionKey = `${item.id}:${questionType}:${currentItem}`;
   const isCurrentQuestionAnkiRevealed =
     ankiAnswerRevealed && ankiRevealQuestionKey === currentQuestionKey;
@@ -4585,7 +4606,7 @@ export default function ReviewQuestionScreen({
         if (shouldShowAcceptedAnswersAndSynonyms && otherAcceptedMeaningAnswers.length > 0) {
           rows.push({
             key: "other-accepted-meanings",
-            label: "Other meaning answers",
+            label: `Other ${meaningAnswerDisplayLabel} answers`,
             values: otherAcceptedMeaningAnswers,
           });
         }
@@ -4619,7 +4640,10 @@ export default function ReviewQuestionScreen({
         if (shouldShowAcceptedAnswersAndSynonyms && otherAcceptedMeaningAnswers.length > 0) {
           rows.push({
             key: "other-accepted-meanings",
-            label: "Other accepted answers",
+            label:
+              meaningAnswerDisplayLabel === "name"
+                ? "Other accepted names"
+                : "Other accepted answers",
             values: otherAcceptedMeaningAnswers,
           });
         }
@@ -4669,6 +4693,7 @@ export default function ReviewQuestionScreen({
       ankiPitchAccentDisplayValues,
       ankiPitchAccentEntry,
       effectiveAnkiGroupQuestions,
+      meaningAnswerDisplayLabel,
       otherAcceptedMeaningAnswers,
       otherAcceptedReadingAnswers,
       questionType,
@@ -5591,11 +5616,7 @@ export default function ReviewQuestionScreen({
               >
                 {getSubjectTypeLabel()}{" "}
                 <Text style={styles.bannerTextBold}>
-                  {effectiveAnkiGroupQuestions
-                    ? "Meaning & Reading"
-                    : questionType === "meaning"
-                      ? "Meaning"
-                      : "Reading"}
+                  {groupedQuestionDisplayLabel}
                 </Text>
               </Text>
             </View>
@@ -6254,7 +6275,7 @@ export default function ReviewQuestionScreen({
                   >
                     {getSubjectTypeLabel()}{" "}
                     <Text style={styles.bannerTextBold}>
-                      {questionType === "meaning" ? "Meaning" : "Reading"}
+                      {questionTypeDisplayLabel}
                     </Text>
                   </Text>
                 </View>

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -56,6 +56,18 @@ export const getCurrentPatchNotesVersion = (): string => {
 // Patch notes data - add new entries at the TOP of this array
 export const PATCH_NOTES: PatchNote[] = [
   {
+    version: "1.2.87",
+    date: "2026-06-23",
+    changes: [
+      {
+        type: "fix",
+        title: "Radical Name Questions",
+        description:
+          "Radical review and lesson quiz prompts now ask for the radical name instead of calling it a meaning question.",
+      },
+    ],
+  },
+  {
     version: "1.2.86",
     date: "2026-06-22",
     changes: [


### PR DESCRIPTION
## Summary
- Show radical review and lesson quiz prompts as “Name” instead of “Meaning”.
- Update Anki accepted-answer labels so radical answers are described as names.
- Addresses https://github.com/Portego-00/Kakehashi/issues/46
