### PR TITLE
[Fix] Persist level timing exclusions

### DIFF
--- a/src/components/LevelTimingChart.tsx
+++ b/src/components/LevelTimingChart.tsx
@@ -156,6 +156,7 @@ export default function LevelTimingChart({
     (state) => state.widgetLevelTimingResetColor,
   );
   const scrollViewRef = useRef<ScrollView>(null);
+  const shouldPersistDisabledLevelsRef = useRef(false);
   const [disabledLevels, setDisabledLevels] = useState<number[]>([]);
   const [disabledLevelsHydrated, setDisabledLevelsHydrated] = useState(false);
 
@@ -232,8 +233,8 @@ export default function LevelTimingChart({
 
   useEffect(() => {
     let isCancelled = false;
-    setDisabledLevels([]);
     setDisabledLevelsHydrated(false);
+    shouldPersistDisabledLevelsRef.current = false;
 
     const loadDisabledLevels = async () => {
       try {
@@ -263,10 +264,11 @@ export default function LevelTimingChart({
   }, [authUserId]);
 
   useEffect(() => {
-    if (!disabledLevelsHydrated) {
+    if (!disabledLevelsHydrated || !shouldPersistDisabledLevelsRef.current) {
       return;
     }
 
+    shouldPersistDisabledLevelsRef.current = false;
     saveLevelTimingExcludedLevels(authUserId, disabledLevels).catch((error) => {
       console.warn("Failed to save level timing excluded levels", error);
     });
@@ -300,38 +302,28 @@ export default function LevelTimingChart({
     return levels;
   }, [levelTimingData]);
 
-  useEffect(() => {
-    if (!disabledLevelsHydrated) {
-      return;
-    }
-
-    setDisabledLevels((current) => {
-      const filtered = current.filter((level) =>
-        toggleableCompletedLevelSet.has(level),
-      );
-      if (filtered.length === current.length) {
-        return current;
-      }
-      return filtered;
-    });
-  }, [disabledLevelsHydrated, toggleableCompletedLevelSet]);
+  const activeDisabledLevels = useMemo(
+    () => (disabledLevelsHydrated ? disabledLevels : []),
+    [disabledLevels, disabledLevelsHydrated],
+  );
 
   const excludedCompletedLevelSet = useMemo(() => {
     const levels = new Set<number>();
-    for (const level of disabledLevels) {
+    for (const level of activeDisabledLevels) {
       if (toggleableCompletedLevelSet.has(level)) {
         levels.add(level);
       }
     }
     return levels;
-  }, [disabledLevels, toggleableCompletedLevelSet]);
+  }, [activeDisabledLevels, toggleableCompletedLevelSet]);
 
   const toggleLevelExclusion = useCallback(
     (level: number) => {
-      if (!toggleableCompletedLevelSet.has(level)) {
+      if (!disabledLevelsHydrated || !toggleableCompletedLevelSet.has(level)) {
         return;
       }
 
+      shouldPersistDisabledLevelsRef.current = true;
       setDisabledLevels((current) => {
         if (current.includes(level)) {
           return current.filter((item) => item !== level);
@@ -340,7 +332,7 @@ export default function LevelTimingChart({
         return [...current, level].sort((a, b) => a - b);
       });
     },
-    [toggleableCompletedLevelSet],
+    [disabledLevelsHydrated, toggleableCompletedLevelSet],
   );
 
   const chartRenderItems: ChartRenderItem[] = useMemo(() => {
@@ -650,86 +642,87 @@ export default function LevelTimingChart({
             const barHeight = Math.max((levelData.timeInDays / maxTime) * 120, 8);
             const barColor = getBarColor(levelData);
             const isExcluded = excludedCompletedLevelSet.has(levelData.level);
-            const isToggleable = levelData.isComplete && !levelData.isCurrent;
+            const isToggleable =
+              disabledLevelsHydrated && levelData.isComplete && !levelData.isCurrent;
 
             return (
               <Animated.View
                 key={item.key}
                 entering={FadeInDown.delay(index * 50).duration(300)}
-                  style={[
-                    styles.chartBarContainer,
-                    { width: BAR_CONTAINER_WIDTH },
+                style={[
+                  styles.chartBarContainer,
+                  { width: BAR_CONTAINER_WIDTH },
+                ]}
+              >
+                <Pressable
+                  onPress={() => toggleLevelExclusion(levelData.level)}
+                  disabled={!isToggleable}
+                  hitSlop={6}
+                  style={({ pressed }) => [
+                    styles.levelBarPressable,
+                    pressed && isToggleable && styles.levelBarPressablePressed,
                   ]}
+                  accessibilityRole={isToggleable ? "button" : undefined}
+                  accessibilityState={
+                    isToggleable ? { selected: isExcluded } : undefined
+                  }
+                  accessibilityLabel={
+                    isToggleable
+                      ? `Level ${levelData.level}, ${isExcluded ? "excluded" : "included"} in averages`
+                      : `Level ${levelData.level}`
+                  }
                 >
-                  <Pressable
-                    onPress={() => toggleLevelExclusion(levelData.level)}
-                    disabled={!isToggleable}
-                    hitSlop={6}
-                    style={({ pressed }) => [
-                      styles.levelBarPressable,
-                      pressed && isToggleable && styles.levelBarPressablePressed,
+                  <Text
+                    style={[
+                      styles.chartBarValue,
+                      {
+                        color: isExcluded ? theme.textLight : theme.textSecondary,
+                        fontSize: VALUE_FONT_SIZE,
+                      },
                     ]}
-                    accessibilityRole={isToggleable ? "button" : undefined}
-                    accessibilityState={
-                      isToggleable ? { selected: isExcluded } : undefined
-                    }
-                    accessibilityLabel={
-                      isToggleable
-                        ? `Level ${levelData.level}, ${isExcluded ? "excluded" : "included"} in averages`
-                        : `Level ${levelData.level}`
-                    }
                   >
-                    <Text
-                      style={[
-                        styles.chartBarValue,
-                        {
-                          color: isExcluded ? theme.textLight : theme.textSecondary,
-                          fontSize: VALUE_FONT_SIZE,
-                        },
-                      ]}
-                    >
-                      {levelData.timeInDays < 10
-                        ? levelData.timeInDays.toFixed(1)
-                        : Math.round(levelData.timeInDays).toString()}
-                      {levelData.isCurrent && "+"}
-                    </Text>
-                    <View
-                      style={[
-                        styles.chartBar,
-                        {
-                          height: barHeight,
-                          backgroundColor: barColor,
-                          opacity: levelData.isCurrent ? 0.7 : 1,
-                          width: BAR_WIDTH,
-                          borderWidth: isExcluded ? 1 : 0,
-                          borderColor: isExcluded
-                            ? withAlpha(theme.textSecondary, theme.isDark ? 0.42 : 0.3)
-                            : "transparent",
-                        },
-                      ]}
-                    />
-                    <Text
-                      style={[
-                        styles.chartBarLabel,
-                        {
-                          color: levelData.isCurrent
-                            ? theme.primary
-                            : isExcluded
-                              ? theme.textLight
-                              : theme.textSecondary,
-                          fontWeight: levelData.isCurrent
-                            ? "bold"
-                            : isExcluded
-                              ? "600"
-                              : "normal",
-                          fontSize: LABEL_FONT_size,
-                          textDecorationLine: isExcluded ? "line-through" : "none",
-                        },
-                      ]}
-                    >
-                      {numberToJapanese(levelData.level)}
-                    </Text>
-                  </Pressable>
+                    {levelData.timeInDays < 10
+                      ? levelData.timeInDays.toFixed(1)
+                      : Math.round(levelData.timeInDays).toString()}
+                    {levelData.isCurrent && "+"}
+                  </Text>
+                  <View
+                    style={[
+                      styles.chartBar,
+                      {
+                        height: barHeight,
+                        backgroundColor: barColor,
+                        opacity: levelData.isCurrent ? 0.7 : 1,
+                        width: BAR_WIDTH,
+                        borderWidth: isExcluded ? 1 : 0,
+                        borderColor: isExcluded
+                          ? withAlpha(theme.textSecondary, theme.isDark ? 0.42 : 0.3)
+                          : "transparent",
+                      },
+                    ]}
+                  />
+                  <Text
+                    style={[
+                      styles.chartBarLabel,
+                      {
+                        color: levelData.isCurrent
+                          ? theme.primary
+                          : isExcluded
+                            ? theme.textLight
+                            : theme.textSecondary,
+                        fontWeight: levelData.isCurrent
+                          ? "bold"
+                          : isExcluded
+                            ? "600"
+                            : "normal",
+                        fontSize: LABEL_FONT_size,
+                        textDecorationLine: isExcluded ? "line-through" : "none",
+                      },
+                    ]}
+                  >
+                    {numberToJapanese(levelData.level)}
+                  </Text>
+                </Pressable>
               </Animated.View>
             );
           })}

--- a/src/data/patchNotes.ts
+++ b/src/data/patchNotes.ts
@@ -65,6 +65,12 @@ export const PATCH_NOTES: PatchNote[] = [
         description:
           "Added a new Extra Study mode for practicing visually similar kanji by matching them to their meanings.",
       },
+      {
+        type: "fix",
+        title: "Level Timing Exclusions",
+        description:
+          "Level Timing now keeps excluded bars saved more reliably across refreshes, reloads, and app restarts.",
+      },
     ],
   },
   {

--- a/src/utils/__tests__/levelTimingExclusions.test.ts
+++ b/src/utils/__tests__/levelTimingExclusions.test.ts
@@ -1,0 +1,73 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  getLevelTimingExcludedStorageKey,
+  loadLevelTimingExcludedLevels,
+  saveLevelTimingExcludedLevels,
+  subscribeLevelTimingExcludedLevels,
+} from "../levelTimingExclusions";
+import { permanentStorage } from "../permanentStorage";
+
+jest.mock("../permanentStorage", () => ({
+  permanentStorage: {
+    getString: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+const asyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const durableStorage = permanentStorage as unknown as {
+  getString: jest.Mock;
+  set: jest.Mock;
+};
+
+describe("levelTimingExclusions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asyncStorage.getItem.mockResolvedValue(null);
+    asyncStorage.setItem.mockResolvedValue(undefined);
+    durableStorage.getString.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads from durable storage before checking legacy AsyncStorage", async () => {
+    durableStorage.getString.mockReturnValue(JSON.stringify([3, "2", 2, 1.8]));
+
+    await expect(loadLevelTimingExcludedLevels("user-1")).resolves.toEqual([
+      1, 2, 3,
+    ]);
+
+    expect(asyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it("migrates legacy AsyncStorage values into durable storage", async () => {
+    const storageKey = getLevelTimingExcludedStorageKey("user-1");
+    asyncStorage.getItem.mockResolvedValue(JSON.stringify([7, 4, 4]));
+
+    await expect(loadLevelTimingExcludedLevels("user-1")).resolves.toEqual([
+      4, 7,
+    ]);
+
+    expect(durableStorage.set).toHaveBeenCalledWith(storageKey, "[4,7]");
+  });
+
+  it("saves normalized levels to durable storage and mirrors them to AsyncStorage", async () => {
+    const storageKey = getLevelTimingExcludedStorageKey("user-1");
+    const listener = jest.fn();
+    const unsubscribe = subscribeLevelTimingExcludedLevels(listener);
+
+    await saveLevelTimingExcludedLevels(
+      "user-1",
+      [9, 3.6, 9, 0] as unknown as number[]
+    );
+
+    expect(durableStorage.set).toHaveBeenCalledWith(storageKey, "[3,9]");
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(storageKey, "[3,9]");
+    expect(listener).toHaveBeenCalledWith("user-1", [3, 9]);
+
+    unsubscribe();
+  });
+});

--- a/src/utils/levelTimingExclusions.ts
+++ b/src/utils/levelTimingExclusions.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { permanentStorage } from "./permanentStorage";
 
 export const LEVEL_TIMING_EXCLUDED_STORAGE_KEY_PREFIX =
   "wanikani_level_timing_disabled_levels_v1";
@@ -43,6 +44,20 @@ export function getLevelTimingExcludedStorageKey(
   return `${LEVEL_TIMING_EXCLUDED_STORAGE_KEY_PREFIX}:${userId ?? "anonymous"}`;
 }
 
+function parseLevelTimingExcludedLevels(
+  raw: string | null | undefined
+): number[] | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return normalizeLevelTimingExcludedLevels(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
 function notifyLevelTimingExcludedLevelsChanged(
   userId: string | null,
   levels: number[]
@@ -65,12 +80,48 @@ export function subscribeLevelTimingExcludedLevels(
 export async function loadLevelTimingExcludedLevels(
   userId: string | null | undefined
 ): Promise<number[]> {
-  const raw = await AsyncStorage.getItem(getLevelTimingExcludedStorageKey(userId));
-  if (!raw) {
+  const storageKey = getLevelTimingExcludedStorageKey(userId);
+
+  try {
+    const durableLevels = parseLevelTimingExcludedLevels(
+      permanentStorage.getString(storageKey)
+    );
+    if (durableLevels) {
+      return durableLevels;
+    }
+  } catch (error) {
+    console.warn(
+      "Failed to read level timing exclusions from durable storage:",
+      error
+    );
+  }
+
+  let legacyRaw: string | null = null;
+  try {
+    legacyRaw = await AsyncStorage.getItem(storageKey);
+  } catch (error) {
+    console.warn(
+      "Failed to read level timing exclusions from AsyncStorage:",
+      error
+    );
     return [];
   }
 
-  return normalizeLevelTimingExcludedLevels(JSON.parse(raw));
+  const legacyLevels = parseLevelTimingExcludedLevels(legacyRaw);
+  if (!legacyLevels) {
+    return [];
+  }
+
+  try {
+    permanentStorage.set(storageKey, JSON.stringify(legacyLevels));
+  } catch (error) {
+    console.warn(
+      "Failed to migrate level timing exclusions to durable storage:",
+      error
+    );
+  }
+
+  return legacyLevels;
 }
 
 export async function saveLevelTimingExcludedLevels(
@@ -78,9 +129,34 @@ export async function saveLevelTimingExcludedLevels(
   levels: readonly number[]
 ): Promise<void> {
   const normalizedLevels = normalizeLevelTimingExcludedLevels([...levels]);
-  await AsyncStorage.setItem(
-    getLevelTimingExcludedStorageKey(userId),
-    JSON.stringify(normalizedLevels)
-  );
-  notifyLevelTimingExcludedLevelsChanged(userId ?? null, normalizedLevels);
+  const storageKey = getLevelTimingExcludedStorageKey(userId);
+  const serializedLevels = JSON.stringify(normalizedLevels);
+  let savedDurably = false;
+
+  try {
+    permanentStorage.set(storageKey, serializedLevels);
+    savedDurably = true;
+    notifyLevelTimingExcludedLevelsChanged(userId ?? null, normalizedLevels);
+  } catch (error) {
+    console.warn(
+      "Failed to save level timing exclusions to durable storage:",
+      error
+    );
+  }
+
+  try {
+    await AsyncStorage.setItem(storageKey, serializedLevels);
+    if (!savedDurably) {
+      notifyLevelTimingExcludedLevelsChanged(userId ?? null, normalizedLevels);
+    }
+  } catch (error) {
+    if (!savedDurably) {
+      throw error;
+    }
+
+    console.warn(
+      "Failed to mirror level timing exclusions to AsyncStorage:",
+      error
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Persist Level Timing excluded bars in durable MMKV storage, with legacy AsyncStorage migration and mirroring.
- Prevent partial chart reloads from overwriting saved exclusions with an empty or filtered list.
