### PR TITLE
feat: iOS widget background review sync and settings toggle

### DIFF
--- a/app/(app)/widget-settings.tsx
+++ b/app/(app)/widget-settings.tsx
@@ -7,11 +7,13 @@ import {
   Platform,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import WaniKaniBackgroundFetch from "../../src/modules/WaniKaniBackgroundFetch";
 import {
   type WidgetContentMode,
   type WidgetStreakGradientPreset,
@@ -100,6 +102,8 @@ export default function WidgetSettings() {
     setWidgetContentMode,
     widgetStreakGradient,
     setWidgetStreakGradient,
+    widgetBackgroundRefreshEnabled,
+    setWidgetBackgroundRefreshEnabled,
   } = useSettingsStore();
   const isIOS = Platform.OS === "ios";
   const isPortegoDebugUser =
@@ -109,6 +113,23 @@ export default function WidgetSettings() {
   const [isWidgetDebugLoading, setIsWidgetDebugLoading] = useState(false);
   const [widgetDebugLastRefreshedAt, setWidgetDebugLastRefreshedAt] =
     useState<Date | null>(null);
+
+  const handleWidgetBackgroundRefreshChange = (enabled: boolean) => {
+    setWidgetBackgroundRefreshEnabled(enabled);
+    if (
+      Platform.OS === "ios" &&
+      WaniKaniBackgroundFetch &&
+      typeof WaniKaniBackgroundFetch.updateNotificationSettings === "function"
+    ) {
+      try {
+        WaniKaniBackgroundFetch.updateNotificationSettings({
+          widgetBackgroundRefreshEnabled: enabled,
+        });
+      } catch {
+        // Best effort
+      }
+    }
+  };
 
   const handleWidgetContentModeChange = (mode: WidgetContentMode) => {
     setWidgetContentMode(mode);
@@ -396,6 +417,57 @@ export default function WidgetSettings() {
                   );
                 })}
               </View>
+            </View>
+          </View>
+        ) : null}
+
+        {isIOS ? (
+          <View
+            style={[
+              styles.section,
+              {
+                backgroundColor: theme.cardBackground,
+                borderColor: theme.border,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.sectionTitle,
+                { color: theme.textColor, borderBottomColor: theme.border },
+              ]}
+            >
+              Background Updates
+            </Text>
+
+            <View
+              style={[styles.settingItem, { borderBottomColor: "transparent" }]}
+            >
+              <Ionicons
+                name="sync"
+                size={24}
+                color={theme.primary}
+                style={styles.settingIcon}
+              />
+              <View style={styles.settingTextContainer}>
+                <Text style={[styles.settingText, { color: theme.textColor }]}>
+                  Background Refresh
+                </Text>
+                <Text
+                  style={[
+                    styles.settingSubtext,
+                    { color: theme.textSecondary },
+                  ]}
+                >
+                  Periodically check for external reviews and keep widget counts up to date when the app is closed
+                </Text>
+              </View>
+              <Switch
+                value={widgetBackgroundRefreshEnabled}
+                onValueChange={handleWidgetBackgroundRefreshChange}
+                trackColor={{ false: "#767577", true: theme.primary }}
+                thumbColor="#f4f3f4"
+              />
             </View>
           </View>
         ) : null}

--- a/ios/ReviewNotificationManager.swift
+++ b/ios/ReviewNotificationManager.swift
@@ -12,7 +12,7 @@ import WidgetKit
 
 // Simple widget data storage for notifications
 private func saveWidgetData(currentReviews: Int, upcomingReviews: [Int], upcomingReviewTimes: [String: Int]?) {
-    guard let sharedDefaults = UserDefaults(suiteName: "group.com.wanikani.reviewdata") else {
+    guard let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata") else {
         print("❌ Failed to access App Group UserDefaults")
         return
     }
@@ -491,7 +491,7 @@ class ReviewNotificationManager: NSObject {
     print("📱 ReviewNotificationManager.updateWidgetData called at \(timestamp) with: currentReviews=\(currentReviews)")
     NSLog("📱 ReviewNotificationManager.updateWidgetData called at %@ with: currentReviews=%d", timestamp, currentReviews)
     
-    guard let sharedDefaults = UserDefaults(suiteName: "group.com.wanikani.reviewdata") else {
+    guard let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata") else {
       print("❌ Failed to access App Group UserDefaults")
       return
     }
@@ -511,7 +511,7 @@ class ReviewNotificationManager: NSObject {
     // Tell WidgetKit to reload widgets
     DispatchQueue.main.async {
       WidgetCenter.shared.reloadAllTimelines()
-      WidgetCenter.shared.reloadTimelines(ofKind: "WaniKaniWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "KakehashiHomeWidget")
       print("🔄 ReviewNotificationManager: Widget reload requested")
       NSLog("🔄 ReviewNotificationManager: Widget reload requested")
     }
@@ -703,7 +703,7 @@ class ReviewNotificationManager: NSObject {
     print("🧪 ReviewNotificationManager: Scheduling test widget updates")
     
     // Get current review data
-    guard let sharedDefaults = UserDefaults(suiteName: "group.com.wanikani.reviewdata"),
+    guard let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata"),
           let currentData = sharedDefaults.object(forKey: "waniKaniReviewData") as? [String: Any],
           let currentReviews = currentData["currentReviews"] as? Int else {
       // Use default values if no current data

--- a/ios/SharedReviewData.swift
+++ b/ios/SharedReviewData.swift
@@ -20,7 +20,7 @@ struct WaniKaniReviewData: Codable {
 // Shared UserDefaults for App Group communication
 class SharedReviewDataManager {
     static let shared = SharedReviewDataManager()
-    private let appGroupIdentifier = "group.com.wanikani.reviewdata"
+    private let appGroupIdentifier = "group.com.kakehashi.reviewdata"
     private let reviewDataKey = "waniKaniReviewData"
     
     private var sharedDefaults: UserDefaults? {

--- a/ios/WaniKaniBackgroundFetch.swift
+++ b/ios/WaniKaniBackgroundFetch.swift
@@ -40,6 +40,9 @@ class WaniKaniBackgroundFetch: NSObject {
     self.lastApiToken = apiToken
     // Store API token for background fetch
     UserDefaults.standard.set(apiToken, forKey: "wanikani_api_token")
+    if let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata") {
+      sharedDefaults.set(apiToken, forKey: "wanikani_api_token")
+    }
   }
   
   @objc
@@ -48,6 +51,9 @@ class WaniKaniBackgroundFetch: NSObject {
     UserDefaults.standard.set(settings["badgeEnabled"] as? Bool ?? true, forKey: "badge_notifications_enabled")
     UserDefaults.standard.set(settings["alertsEnabled"] as? Bool ?? false, forKey: "review_notifications_enabled")
     UserDefaults.standard.set(settings["soundsEnabled"] as? Bool ?? true, forKey: "notification_sounds_enabled")
+    if let widgetRefresh = settings["widgetBackgroundRefreshEnabled"] as? Bool {
+      UserDefaults.standard.set(widgetRefresh, forKey: "widget_background_refresh_enabled")
+    }
   }
   
   @objc
@@ -153,15 +159,20 @@ class WaniKaniBackgroundFetch: NSObject {
         
         // Wait for badge update to complete, then update widget and finish
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-          // Update widget with new review data on main queue
-          print("🔍 About to update widget with: currentReviews=\(data.reviewCount), upcomingReviews=\(data.upcomingReviews.reduce(0, +))")
-          NSLog("🔍 About to update widget with: currentReviews=%d, upcomingReviews=%d", data.reviewCount, data.upcomingReviews.reduce(0, +))
-          
-          self?.updateWidgetData(
-            currentReviews: data.reviewCount,
-            upcomingReviews: data.upcomingReviews,
-            upcomingReviewTimes: nil // Will be populated later if needed
-          )
+          let widgetRefreshEnabled = UserDefaults.standard.object(forKey: "widget_background_refresh_enabled") as? Bool ?? true
+          if widgetRefreshEnabled {
+            // Update widget with new review data on main queue
+            print("🔍 About to update widget with: currentReviews=\(data.reviewCount), upcomingReviews=\(data.upcomingReviews.reduce(0, +))")
+            NSLog("🔍 About to update widget with: currentReviews=%d, upcomingReviews=%d", data.reviewCount, data.upcomingReviews.reduce(0, +))
+            
+            self?.updateWidgetData(
+              currentReviews: data.reviewCount,
+              upcomingReviews: data.upcomingReviews,
+              upcomingReviewTimes: nil // Will be populated later if needed
+            )
+          } else {
+            print("⏭️ Background Fetch: Widget refresh disabled by user setting")
+          }
           
           // Wait a bit more for widget update to complete
           DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -497,7 +508,7 @@ class WaniKaniBackgroundFetch: NSObject {
     print("📱 updateWidgetData called at \(timestamp) with: currentReviews=\(currentReviews), upcoming=\(upcomingReviews.reduce(0, +))")
     NSLog("📱 updateWidgetData called at %@ with: currentReviews=%d, upcoming=%d", timestamp, currentReviews, upcomingReviews.reduce(0, +))
     
-    guard let sharedDefaults = UserDefaults(suiteName: "group.com.wanikani.reviewdata") else {
+    guard let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata") else {
       print("❌ Failed to access App Group UserDefaults")
       return
     }
@@ -532,9 +543,9 @@ class WaniKaniBackgroundFetch: NSObject {
         print("🔄 Requesting specific widget reload...")
         NSLog("🔄 Requesting specific widget reload...")
         
-        WidgetCenter.shared.reloadTimelines(ofKind: "WaniKaniWidget")
-        print("✅ WaniKani widgets reloaded with new review data")
-        NSLog("✅ WaniKani widgets reloaded with new review data")
+        WidgetCenter.shared.reloadTimelines(ofKind: "KakehashiHomeWidget")
+        print("✅ Kakehashi widgets reloaded with new review data")
+        NSLog("✅ Kakehashi widgets reloaded with new review data")
         
         // Another reload all as backup
         WidgetCenter.shared.reloadAllTimelines()

--- a/ios/wanikani/AppDelegate.swift
+++ b/ios/wanikani/AppDelegate.swift
@@ -77,9 +77,17 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
   ) {
-    // Use the WaniKaniBackgroundFetch module to perform background fetch
-    let backgroundFetch = WaniKaniBackgroundFetch()
-    backgroundFetch.performBackgroundFetch(completionHandler: completionHandler)
+    // Delegate to Expo background task system first so TaskManager tasks execute
+    super.application(application, performFetchWithCompletionHandler: { expoResult in
+      // Also perform native background fetch
+      let backgroundFetch = WaniKaniBackgroundFetch()
+      backgroundFetch.performBackgroundFetch { nativeResult in
+        let finalResult: UIBackgroundFetchResult =
+          (expoResult == .newData || nativeResult == .newData) ? .newData :
+          (expoResult == .failed && nativeResult == .failed) ? .failed : .noData
+        completionHandler(finalResult)
+      }
+    })
   }
   
   // MARK: - Badge and Notification Management
@@ -116,7 +124,7 @@ public class AppDelegate: ExpoAppDelegate {
     print("📱 AppDelegate: Updating widget with \(currentReviews) reviews from scheduled notification")
     
     // Update widget data in shared App Group
-    guard let sharedDefaults = UserDefaults(suiteName: "group.com.wanikani.reviewdata") else {
+    guard let sharedDefaults = UserDefaults(suiteName: "group.com.kakehashi.reviewdata") else {
       print("❌ AppDelegate: Failed to access App Group UserDefaults")
       return
     }
@@ -136,7 +144,7 @@ public class AppDelegate: ExpoAppDelegate {
     // Reload widget timelines
     DispatchQueue.main.async {
       WidgetCenter.shared.reloadAllTimelines()
-      WidgetCenter.shared.reloadTimelines(ofKind: "WaniKaniWidget")
+      WidgetCenter.shared.reloadTimelines(ofKind: "KakehashiHomeWidget")
       print("🔄 AppDelegate: Widget reload completed")
       NSLog("🔄 AppDelegate: Widget reload completed")
     }

--- a/ios/wanikani/WaniKaniSharedData.swift
+++ b/ios/wanikani/WaniKaniSharedData.swift
@@ -21,7 +21,7 @@ struct WaniKaniReviewData: Codable {
 // Shared UserDefaults for App Group communication
 class SharedReviewDataManager {
     static let shared = SharedReviewDataManager()
-    private let appGroupIdentifier = "group.com.wanikani.reviewdata"
+    private let appGroupIdentifier = "group.com.kakehashi.reviewdata"
     private let reviewDataKey = "waniKaniReviewData"
     
     private var sharedDefaults: UserDefaults? {

--- a/src/modules/WaniKaniBackgroundFetch.ts
+++ b/src/modules/WaniKaniBackgroundFetch.ts
@@ -18,9 +18,10 @@ interface BackgroundFetchResult {
 interface WaniKaniBackgroundFetchModule {
   storeApiToken(apiToken: string): void;
   updateNotificationSettings(settings: {
-    badgeEnabled: boolean;
-    alertsEnabled: boolean;
-    soundsEnabled: boolean;
+    badgeEnabled?: boolean;
+    alertsEnabled?: boolean;
+    soundsEnabled?: boolean;
+    widgetBackgroundRefreshEnabled?: boolean;
   }): void;
   getBackgroundFetchStatus(): BackgroundFetchStatus;
   triggerBackgroundFetchManually(): Promise<BackgroundFetchResult>;

--- a/src/utils/__tests__/widgetBackgroundRefreshSettings.test.ts
+++ b/src/utils/__tests__/widgetBackgroundRefreshSettings.test.ts
@@ -1,0 +1,27 @@
+import { useSettingsStore } from "../store";
+
+describe("widget background refresh setting", () => {
+  afterEach(() => {
+    useSettingsStore.setState({
+      widgetBackgroundRefreshEnabled: true,
+    });
+  });
+
+  it("enables background refresh by default", () => {
+    expect(
+      useSettingsStore.getInitialState().widgetBackgroundRefreshEnabled,
+    ).toBe(true);
+  });
+
+  it("can toggle background refresh setting", () => {
+    useSettingsStore.getState().setWidgetBackgroundRefreshEnabled(false);
+    expect(
+      useSettingsStore.getState().widgetBackgroundRefreshEnabled,
+    ).toBe(false);
+
+    useSettingsStore.getState().setWidgetBackgroundRefreshEnabled(true);
+    expect(
+      useSettingsStore.getState().widgetBackgroundRefreshEnabled,
+    ).toBe(true);
+  });
+});

--- a/src/utils/badgeNotifications.ts
+++ b/src/utils/badgeNotifications.ts
@@ -1,7 +1,13 @@
+import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
-import { getReviewCount, getStoredApiToken, type VisibleReviewData } from './api';
+import {
+  getReviewCount,
+  getStoredApiToken,
+  getVisibleReviewData,
+  type VisibleReviewData,
+} from './api';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   updateBadgeAndScheduleNotifications,
@@ -51,6 +57,38 @@ async function isReviewNotificationsEnabled(): Promise<boolean> {
   }
 }
 
+// Helper function to check if widget background refresh is enabled
+async function isWidgetBackgroundRefreshEnabled(): Promise<boolean> {
+  try {
+    const settings = await AsyncStorage.getItem('wanikani-settings');
+    if (settings) {
+      const parsedSettings = JSON.parse(settings);
+      return parsedSettings.state?.widgetBackgroundRefreshEnabled ?? true; // Default to true
+    }
+    return true; // Default to true if no settings found
+  } catch (error) {
+    console.error('Error checking widget background refresh setting:', error);
+    return true; // Default to true on error
+  }
+}
+
+async function syncHomeWidgetIfSupported(reviewData: {
+  currentReviews: number;
+  upcomingReviews?: number[];
+  upcomingReviewTimes?: { [key: string]: number };
+}): Promise<void> {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { syncHomeWidgetFromBackgroundReviewData } = require('../widgets/homeWidget');
+    await syncHomeWidgetFromBackgroundReviewData(reviewData);
+  } catch (error) {
+    console.warn('Background widget sync error:', error);
+  }
+}
+
 if (NOTIFICATION_RUNTIME_SUPPORTED) {
   const isBackgroundFetchTaskAlreadyDefined =
     typeof TaskManager.isTaskDefined === 'function' &&
@@ -82,11 +120,29 @@ if (NOTIFICATION_RUNTIME_SUPPORTED) {
           return BackgroundTask.BackgroundTaskResult.Success;
         }
 
+        let visibleReviewData: VisibleReviewData | null = null;
+        try {
+          visibleReviewData = await getVisibleReviewData(apiToken, {
+            hoursAhead: 24,
+          });
+        } catch {
+          // Visible review fetch failed, fall back to review count below.
+        }
+
+        const widgetRefreshEnabled = await isWidgetBackgroundRefreshEnabled();
+        if (widgetRefreshEnabled && visibleReviewData) {
+          await syncHomeWidgetIfSupported(visibleReviewData);
+        }
+
         // Use native notification manager when available
         if (USE_NATIVE_NOTIFICATION_SYSTEM) {
           try {
-            await updateBadgeAndScheduleNotifications();
-            await syncDailyReminderNotifications();
+            await updateBadgeAndScheduleNotifications({
+              visibleReviewData: visibleReviewData ?? undefined,
+            });
+            await syncDailyReminderNotifications({
+              reviewCount: visibleReviewData?.currentReviews,
+            });
             return BackgroundTask.BackgroundTaskResult.Success;
           } catch {
             // Fall back to Expo notifications below
@@ -101,7 +157,16 @@ if (NOTIFICATION_RUNTIME_SUPPORTED) {
         const reviewNotificationsEnabled = await isReviewNotificationsEnabled();
 
         // Get current review count (we need this for both features)
-        const reviewCount = await getReviewCount(apiToken);
+        const reviewCount =
+          visibleReviewData?.currentReviews ?? (await getReviewCount(apiToken));
+
+        if (widgetRefreshEnabled && !visibleReviewData) {
+          await syncHomeWidgetIfSupported({
+            currentReviews: reviewCount,
+            upcomingReviews: [],
+            upcomingReviewTimes: {},
+          });
+        }
 
         // Handle badge notifications
         if (badgeEnabled) {
@@ -156,7 +221,7 @@ export async function initializeBadgeNotifications(): Promise<void> {
       // Still register background fetch for periodic updates
       try {
         await BackgroundTask.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-          minimumInterval: 60, // 1 hour in minutes
+          minimumInterval: 15, // 15 minutes (iOS system minimum interval)
         });
       } catch {
         // Background fetch registration failed - continue anyway
@@ -172,7 +237,7 @@ export async function initializeBadgeNotifications(): Promise<void> {
     // Try to register background fetch task
     try {
       await BackgroundTask.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-        minimumInterval: 60, // 1 hour in minutes
+        minimumInterval: 15, // 15 minutes (iOS system minimum interval)
       });
     } catch {
       // Background fetch registration failed - continue anyway
@@ -207,6 +272,13 @@ export async function updateBadgeWithReviewCount(
 
   badgeUpdateInFlight = (async () => {
     try {
+      if (options.visibleReviewData) {
+        const widgetRefreshEnabled = await isWidgetBackgroundRefreshEnabled();
+        if (widgetRefreshEnabled) {
+          await syncHomeWidgetIfSupported(options.visibleReviewData);
+        }
+      }
+
       let reviewCountForReminder =
         typeof options.visibleReviewData?.currentReviews === 'number'
           ? Math.max(0, options.visibleReviewData.currentReviews)

--- a/src/utils/reviewNotificationIntegration.ts
+++ b/src/utils/reviewNotificationIntegration.ts
@@ -31,6 +31,7 @@ async function getNotificationSettings(): Promise<{
   badgeEnabled: boolean;
   alertsEnabled: boolean;
   soundsEnabled: boolean;
+  widgetBackgroundRefreshEnabled?: boolean;
 }> {
   try {
     const settings = await AsyncStorage.getItem(SETTINGS_KEY);
@@ -40,12 +41,15 @@ async function getNotificationSettings(): Promise<{
         badgeEnabled: parsedSettings.state?.showBadgeNotifications ?? true,
         alertsEnabled: parsedSettings.state?.enableReviewNotifications ?? false,
         soundsEnabled: parsedSettings.state?.notificationSounds ?? true,
+        widgetBackgroundRefreshEnabled:
+          parsedSettings.state?.widgetBackgroundRefreshEnabled ?? true,
       };
     }
     return {
       badgeEnabled: true,
       alertsEnabled: false,
       soundsEnabled: true,
+      widgetBackgroundRefreshEnabled: true,
     };
   } catch (error) {
     console.error('Error getting notification settings:', error);
@@ -53,6 +57,7 @@ async function getNotificationSettings(): Promise<{
       badgeEnabled: true,
       alertsEnabled: false,
       soundsEnabled: true,
+      widgetBackgroundRefreshEnabled: true,
     };
   }
 }

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -650,6 +650,7 @@ type SettingsState = {
   // Widget customization
   widgetContentMode: WidgetContentMode;
   widgetStreakGradient: WidgetStreakGradientPreset;
+  widgetBackgroundRefreshEnabled: boolean;
   widgetCardsFollowTheme: boolean;
   widgetLessonCardFollowTheme: boolean;
   widgetReviewCardFollowTheme: boolean;
@@ -823,6 +824,7 @@ type SettingsState = {
   ) => void;
   setWidgetContentMode: (mode: WidgetContentMode) => void;
   setWidgetStreakGradient: (preset: WidgetStreakGradientPreset) => void;
+  setWidgetBackgroundRefreshEnabled: (enabled: boolean) => void;
   setWidgetCardsFollowTheme: (follow: boolean) => void;
   setWidgetLessonCardFollowTheme: (follow: boolean) => void;
   setWidgetReviewCardFollowTheme: (follow: boolean) => void;
@@ -980,6 +982,7 @@ export const useSettingsStore = create<SettingsState>()(
       homeSrsBreakdownDisplayMode: "combined",
       widgetContentMode: "reviews",
       widgetStreakGradient: "sunset",
+      widgetBackgroundRefreshEnabled: true,
       widgetCardsFollowTheme: true,
       widgetLessonCardFollowTheme: true,
       widgetReviewCardFollowTheme: true,
@@ -1337,6 +1340,8 @@ export const useSettingsStore = create<SettingsState>()(
       setWidgetContentMode: (mode) => set({ widgetContentMode: mode }),
       setWidgetStreakGradient: (preset) =>
         set({ widgetStreakGradient: preset }),
+      setWidgetBackgroundRefreshEnabled: (enabled) =>
+        set({ widgetBackgroundRefreshEnabled: enabled }),
       setWidgetCardsFollowTheme: (follow) =>
         set({ widgetCardsFollowTheme: follow }),
       setWidgetLessonCardFollowTheme: (follow) =>

--- a/src/widgets/homeWidget.tsx
+++ b/src/widgets/homeWidget.tsx
@@ -25,6 +25,7 @@ import {
   shadow,
   widgetAccentedRenderingMode,
 } from "@expo/ui/swift-ui/modifiers";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Asset } from "expo-asset";
 import { Directory, File, Paths } from "expo-file-system";
 import type { Widget, WidgetEnvironment } from "expo-widgets";
@@ -36,6 +37,7 @@ import type {
 
 export const KAKEHASHI_HOME_WIDGET_NAME = "KakehashiHomeWidget";
 const WIDGET_APP_GROUP_IDENTIFIER = "group.com.kakehashi.reviewdata";
+const LAST_WIDGET_SNAPSHOT_STORAGE_KEY = "kakehashi-last-widget-snapshot-input";
 const STREAK_ICON_VERSION = "v5";
 const REVIEW_ILLUSTRATION_VERSION = "v6";
 const REVIEW_ACCESSORY_ICON_VERSION = "v2";
@@ -1957,6 +1959,14 @@ function sanitizeWidgetPropsForNative(props: HomeWidgetProps): HomeWidgetProps {
 export function updateHomeWidgetSnapshot(input: HomeWidgetSnapshotInput) {
   const normalizedInput = normalizeSnapshotInputForLiveStreakSession(input);
   latestWidgetSnapshotInput = normalizedInput;
+  try {
+    void AsyncStorage.setItem(
+      LAST_WIDGET_SNAPSHOT_STORAGE_KEY,
+      JSON.stringify(normalizedInput),
+    );
+  } catch {
+    // Best effort only.
+  }
 
   const updateTimelineWithProps = (snapshotInput: HomeWidgetSnapshotInput) => {
     const reviewIllustrationUris = cachedReviewIllustrationUris ?? {};
@@ -2177,3 +2187,84 @@ export function reloadHomeWidget() {
     // Ignore reload errors. This function is best effort only.
   }
 }
+
+export type BackgroundReviewSyncData = {
+  currentReviews: number;
+  upcomingReviews?: number[];
+  upcomingReviewTimes?: { [key: string]: number };
+};
+
+export async function getLastWidgetSnapshotInput(): Promise<HomeWidgetSnapshotInput | null> {
+  if (latestWidgetSnapshotInput) {
+    return latestWidgetSnapshotInput;
+  }
+  try {
+    const raw = await AsyncStorage.getItem(LAST_WIDGET_SNAPSHOT_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as HomeWidgetSnapshotInput;
+      latestWidgetSnapshotInput = parsed;
+      return parsed;
+    }
+  } catch {
+    // Best effort only.
+  }
+  return null;
+}
+
+export async function syncHomeWidgetFromBackgroundReviewData(
+  reviewData: BackgroundReviewSyncData,
+): Promise<void> {
+  if (Platform.OS !== "ios") {
+    return;
+  }
+
+  const existingInput = await getLastWidgetSnapshotInput();
+  const now = new Date();
+  const nowMs = now.getTime();
+
+  const upcomingBuckets: ReviewUpcomingBucket[] = [];
+  let earliestFutureReviewTime: string | null = null;
+  let earliestFutureMs = Number.POSITIVE_INFINITY;
+
+  if (reviewData.upcomingReviewTimes) {
+    for (const [isoDate, count] of Object.entries(reviewData.upcomingReviewTimes)) {
+      if (count <= 0) continue;
+      upcomingBuckets.push({ date: isoDate, count });
+      const ms = Date.parse(isoDate);
+      if (!Number.isNaN(ms) && ms > nowMs && ms < earliestFutureMs) {
+        earliestFutureMs = ms;
+        earliestFutureReviewTime = isoDate;
+      }
+    }
+  }
+
+  const reviewCount = Math.max(0, Math.round(reviewData.currentReviews));
+
+  const updatedInput: HomeWidgetSnapshotInput = {
+    contentMode: existingInput?.contentMode ?? "reviews",
+    streakGradientPreset: existingInput?.streakGradientPreset ?? "defaults",
+    isDarkTheme: existingInput?.isDarkTheme,
+    streakTimezone: existingInput?.streakTimezone,
+    reviewCount,
+    nextReviewDate:
+      earliestFutureReviewTime ??
+      (existingInput?.nextReviewDate ?? null),
+    todayReviewTotal: existingInput?.todayReviewTotal ?? 0,
+    reviewUpcomingBuckets:
+      upcomingBuckets.length > 0
+        ? upcomingBuckets
+        : (existingInput?.reviewUpcomingBuckets ?? []),
+    criticalCount: existingInput?.criticalCount ?? 0,
+    topCriticalItem: existingInput?.topCriticalItem ?? null,
+    recentMistakesCount: existingInput?.recentMistakesCount ?? 0,
+    currentStreak: existingInput?.currentStreak ?? 0,
+    longestStreak: existingInput?.longestStreak ?? 0,
+    freezeAvailable: existingInput?.freezeAvailable ?? false,
+    freezeDaysUntilReload: existingInput?.freezeDaysUntilReload ?? 7,
+    streakRecentDays: existingInput?.streakRecentDays ?? [],
+  };
+
+  updateHomeWidgetSnapshot(updatedInput);
+  reloadHomeWidget();
+}
+


### PR DESCRIPTION
### Summary
(AI-generated PR)

Resolves an issue where iOS home and lock screen widgets would only update review counts when the app was opened in the foreground, falling out of sync when reviews were completed on the web or other devices.

I wasn't able to test this because I don't have an apple developer account 

### Changes
- **Background Sync**:
  - Persisted the latest widget snapshot configuration to `AsyncStorage` so headless background tasks have access to current styles, theme, and streak preferences.
  - Wired `syncHomeWidgetFromBackgroundReviewData` into `BACKGROUND_FETCH_TASK` in `badgeNotifications.ts` to refresh widget snapshots and timelines when iOS triggers a background fetch.
  - Reduced `minimumInterval` to 15 minutes (the iOS system minimum) for background fetch registration.
- **Settings Toggle**:
  - Added `widgetBackgroundRefreshEnabled` (default: `true`) to `useSettingsStore` and synced it to native `UserDefaults`.
  - Added a "Background Refresh" toggle under a new "Background Updates" section in `app/(app)/widget-settings.tsx`.
- **Native iOS Fixes**:
  - In `AppDelegate.swift`, invoked `super.application(_:performFetchWithCompletionHandler:)` so Expo background tasks are dispatched alongside native fetches.
  - Aligned App Group (`group.com.kakehashi.reviewdata`) and widget kind (`KakehashiHomeWidget`) across `WaniKaniBackgroundFetch.swift`, `ReviewNotificationManager.swift`, and `AppDelegate.swift`.

### Testing
- `npm run lint`: Passed with 0 errors.
- `npm test`: 80 passed of 81 test suites (480 passed, 0 failed).
- Added unit tests in `src/utils/__tests__/widgetBackgroundRefreshSettings.test.ts`.
